### PR TITLE
Open Sourcing Existing Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+*.egg-info
+*.lp

--- a/README.md
+++ b/README.md
@@ -3,12 +3,47 @@
 OLLA (Optimizing the Lifetime and Location of Arrays) makes it possible to train larger deep neural networks on existing hardware. OLLA optimizes the order in which the neural network operators are executed to minimize peak memory usage. Furthermore OLLA eliminates memory fragmentation to ensure that no memory is wasted.
 
 ## Approach
- 
+
 Our approach is described in detail on the [OLLA arXiv paper](https://arxiv.org/abs/2210.12924)
 
 ## Getting Started
 
-The source code will be available soon. 
+Install
+```
+conda create --name olla python=3.9
+conda activate olla
+conda install pytorch torchvision torchaudio torchtext -c pytorch
+pip install pandas intervaltree networkx graphviz
+conda config --add channels http://conda.anaconda.org/gurobi
+conda install gurobi
+pip install pydot
+```
+
+Run benchmarks:
+```
+python benchmarks.py
+```
+
+Run tests:
+```
+python -m unittest tests/dataflow_graph_test.py
+python -m unittest tests/torch_graph_importer_test.py
+python -m unittest tests/torch_graph_importer_test_vision.py
+python -m unittest tests/torch_graph_importer_test_transformers.py
+python -m unittest tests/simulator_test.py
+python -m unittest tests/utils_test.py
+python -m unittest tests/max_cut_test.py
+python -m unittest tests/fx_profiler_test.py
+python -m unittest tests/fx_optimizer_test.py
+python -m unittest tests/torch_scheduler_test.py
+python -m unittest tests/memory_planner_test.py # 1 tests fail
+python -m unittest tests/spill_profiler_test.py
+python -m unittest tests/training_graph_optimizer_test.py
+python -m unittest tests/ilp_solver_test.py
+python -m unittest tests/training_graph_optimizer_large_test.py # 1 test fails
+python -m unittest tests/scheduler_test.py $ 4 out of 8 tests fails
+python -m unittest tests/defragmenter_test.py # 1 out of 4 tests fails
+```
 
 ## Citation
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -1,0 +1,641 @@
+import os
+import time
+import traceback
+from collections import OrderedDict
+from multiprocessing import Process
+
+import pandas as pd
+
+import torch
+import torch.fx
+import torchaudio
+import torchtext
+import torchvision
+
+from olla import simulator, training_graph_optimizer, utils, visualizer
+from olla.torch import torch_graph_importer
+
+# Fix the environment to enable graphviz to work.
+# del os.environ["LD_LIBRARY_PATH"]
+
+
+class Benchmark:
+    def load_model(
+        self,
+        model_name,
+        mode,
+        batch_size=32,
+        device="cpu",
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        render_model=False,
+    ):
+        if model_name == "alexnet":
+            model = torchvision.models.alexnet()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "conformer":
+            input_dim = 80
+            model = torchaudio.models.Conformer(
+                input_dim=input_dim,
+                num_heads=4,
+                ffn_dim=128,
+                num_layers=4,
+                depthwise_conv_kernel_size=31,
+            )
+            lengths = torch.randint(1, 400, (batch_size,))  # (batch,)
+            inp = torch.rand(
+                batch_size, int(lengths.max()), input_dim
+            )  # (batch, num_frames, input_dim)
+            inputs = (inp, lengths)
+        elif model_name == "deeplab":
+            # Also try deeplabv3_mobilenet_v3_large()
+            model = torchvision.models.segmentation.deeplabv3_resnet50()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "efficientnet":
+            model = torchvision.models.efficientnet_b0()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "emformer":
+            model = torchaudio.models.Emformer(
+                512, 8, 2048, 20, 4, right_context_length=1
+            )
+            inp = torch.rand(batch_size, 400, 512)  # batch, num_frames, feature_dim
+            lengths = torch.randint(1, 200, (batch_size,))  # batch
+            inputs = (inp, lengths)
+        elif model_name == "googlenet":
+
+            class GoogleNetWrapper(torch.nn.Module):
+                def __init__(self):
+                    super(GoogleNetWrapper, self).__init__()
+                    self.model = torchvision.models.googlenet()
+
+                def forward(self, x):
+                    rslt = self.model(x)
+                    if self.model.training:
+                        return torch.concat((rslt[0], rslt[1], rslt[2]), dim=-1)
+                    else:
+                        return rslt
+
+            model = GoogleNetWrapper()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "inception":
+
+            class InceptionWrapper(torch.nn.Module):
+                def __init__(self):
+                    super(InceptionWrapper, self).__init__()
+                    self.model = torchvision.models.inception_v3()
+
+                def forward(self, x):
+                    rslt = self.model(x)
+                    if self.model.training:
+                        return torch.concat((rslt.logits, rslt.aux_logits), dim=-1)
+                    else:
+                        return rslt
+
+            model = InceptionWrapper()
+            # Need batch size > 1 when training
+            min_batch_size = max(batch_size, 2) if mode == "train" else batch_size
+            inputs = (torch.randn((min_batch_size, 3, 299, 299)),)
+        elif model_name == "mnasnet":
+            model = torchvision.models.mnasnet0_5()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "mobilenet":
+            model = torchvision.models.mobilenet_v2()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "raft":
+            model = torchvision.models.optical_flow.raft_small()
+            inputs = (
+                torch.randn((batch_size, 3, 520, 960)),
+                torch.randn((batch_size, 3, 520, 960)),
+            )
+        elif model_name == "resnet":
+            model = torchvision.models.resnet18()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "resnet50":
+            model = torchvision.models.resnet50()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "resnet3d":
+            model = torchvision.models.video.r3d_18()
+            inputs = (torch.randn((batch_size, 3, 1, 112, 112)),)
+        elif model_name == "bert":
+            bert_base = torchtext.models.ROBERTA_BASE_ENCODER
+            model = bert_base.get_model()
+            transform = bert_base.transform()
+            input_batch = ["Hello world"] * batch_size
+            inputs = (
+                torchtext.functional.to_tensor(transform(input_batch), padding_value=1),
+            )
+        elif model_name == "squeezenet":
+            model = torchvision.models.squeezenet1_0()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "ssd":
+            model = torchvision.models.detection.ssd300_vgg16()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "swin":
+            model = torchvision.models.swin_t()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "transformer":
+            model = torch.nn.Transformer(
+                nhead=1, num_encoder_layers=1, num_decoder_layers=1
+            )
+            inputs = (
+                torch.rand((10, batch_size, 512)),
+                torch.rand((20, batch_size, 512)),
+            )
+        elif model_name == "transformer_dflt":
+            model = torch.nn.Transformer()
+            inputs = (
+                torch.rand((10, batch_size, 512)),
+                torch.rand((20, batch_size, 512)),
+            )
+        elif model_name == "vgg":
+            model = torchvision.models.vgg11()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "vgg16":
+            model = torchvision.models.vgg16()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "vgg19":
+            model = torchvision.models.vgg19()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "vit":
+            model = torchvision.models.vit_b_16()
+            inputs = (torch.randn((batch_size, 3, 224, 224)),)
+        elif model_name == "xlmr":
+            xlmr_base = torchtext.models.XLMR_BASE_ENCODER
+            model = xlmr_base.get_model()
+            transform = xlmr_base.transform()
+            input_batch = ["Hello world"] * batch_size
+            inputs = (
+                torchtext.functional.to_tensor(transform(input_batch), padding_value=1),
+            )
+
+        if mode == "eval":
+            model.eval()
+
+        if device != "cpu":
+            model.to(device)
+            # convert tuple to list so that we can modify it
+            inputs = list(inputs)
+            for idx, input in enumerate(inputs):
+                inputs[idx] = input.to(device)
+            inputs = tuple(inputs)
+
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        importer = torch_graph_importer.TorchGraphImporter()
+        g, pt_node_order = importer.import_via_aotautograd(
+            model,
+            *inputs,
+            optimizer=optimizer,
+            mode=mode,
+            profile=profile,
+            warm_up_iters=warm_up_iters,
+            profile_iters=profile_iters,
+        )
+        g.name = f"{model_name}_{batch_size}_{mode}"
+
+        # Prevent Pytorch from leaking memory
+        del model
+        del importer.fx_trace
+        del importer
+        torch.cuda.empty_cache()
+
+        assert g.is_valid(verbose=True)
+
+        # Dump the graph in the background
+        if render_model:
+
+            def dump_model():
+                print("  PRINTING MODEL IN THE BACKGROUND", flush=True)
+                with open(
+                    "/tmp/"
+                    + model_name
+                    + "_"
+                    + str(batch_size)
+                    + "_raw_"
+                    + mode
+                    + ".txt",
+                    mode="w",
+                ) as f:
+                    f.write(str(g))
+
+                g.dump(
+                    "/tmp/" + model_name + "_" + str(batch_size) + "_raw_" + mode,
+                    format="svg",
+                )
+
+            p = Process(target=dump_model, name="dump_" + model_name, daemon=False)
+            p.start()
+
+        print("  CANONICALIZING MODEL", flush=True)
+        g.canonicalize()
+        print("  CONSTRAINING WEIGHT UPDATES", flush=True)
+        g.constrain_weight_updates()
+        print("  CONSTRAINING TENSOR GENERATORS", flush=True)
+        g.constrain_tensor_generators()
+
+        print("  CHECKING MODEL", flush=True)
+        assert g.is_valid(verbose=True)
+
+        # model_name = model.__class__.__name__
+        # g.dump("/tmp/" + model_name + "_" + mode, format="svg")
+
+        return g, pt_node_order
+
+    def measure_pt_alloc_time(self, node_ordering, num_times=100):
+        class MemLoc:
+            def __init__(self, size):
+                self.size = size
+                self.address = None
+
+            def run(self):
+                if self.address:
+                    torch.cuda.caching_allocator_delete(self.address)
+                    self.address = None
+                else:
+                    self.address = torch.cuda.caching_allocator_alloc(self.size)
+
+        edge_ref_counts = {}
+        mem_sequence = []
+        mem_locs = {}
+        for n in node_ordering:
+            for fanout in n.fanout:
+                if fanout.size > 0:
+                    edge_ref_counts[fanout] = len(fanout.sinks)
+                    tensor = MemLoc(fanout.size)
+                    mem_sequence.append(tensor)
+                    mem_locs[fanout] = tensor
+
+            for fanin in n.fanin:
+                if fanin.size == 0:
+                    continue
+                edge_ref_counts[fanin] -= 1
+                if edge_ref_counts[fanin] == 0:
+                    tensor = mem_locs[fanin]
+                    mem_sequence.append(tensor)
+
+        start = time.time()
+        for _ in range(num_times):
+            for op in mem_sequence:
+                op.run()
+        stop = time.time()
+        num_alloc_dealloc_pairs = num_times * len(mem_sequence) / 2
+        return (stop - start, num_alloc_dealloc_pairs)
+
+    # TODO: should we have run_profile() as a function here that measures fragmentation, instead of calculating or measuring fragmentation inside TorchGraphImporter? This would decouple profiling from TorchGraphImporter and hence make it easier to run the same script on AWS
+
+    def run_simulation(self, g, node_order):
+        start = time.time()
+        s = simulator.Simulator(g)
+        stop = time.time()
+        simulated_mem_usage, mem_per_timestep = s.Simulate(node_order)
+        return (simulated_mem_usage, stop - start)
+
+    def run_node_ordering(self, g):
+        start = time.time()
+        s = training_graph_optimizer.Scheduler(g, rel_stop=0.005, timeout_s=1800)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            allow_swaps=False,
+            max_spills=0,
+        )
+        stop = time.time()
+
+        assert utils.validate_timeline(schedule)
+        assert utils.validate_node_ordering(g, schedule)
+        assert summary["peak_mem_usage"] == summary["required_memory"]
+        # assert summary["peak_mem_usage"] <= simulated_mem_usage
+        assert summary["total_data_swapped"] == 0
+
+        node_ordering = utils.extract_node_ordering(g, schedule)
+        return (summary["peak_mem_usage"], node_ordering, stop - start)
+
+    def run_address_generation(self, g, node_order):
+        start = time.time()
+        s = training_graph_optimizer.Scheduler(
+            g,
+            rel_stop=0.001,
+            timeout_s=1800,
+            print_relaxation=True,
+        )
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            allow_swaps=False,
+            max_spills=0,
+            account_for_fragmentation=True,
+            user_schedule=node_order,
+        )
+        stop = time.time()
+        peak_mem_usage = summary["required_memory"]
+        fragmentation = (peak_mem_usage - summary["peak_mem_usage"]) / peak_mem_usage
+        assert utils.validate_timeline(schedule)
+        assert utils.validate_address_allocation(mem_loc)
+        assert summary["peak_mem_usage"] <= summary["required_memory"]
+        assert summary["total_data_swapped"] == 0
+
+        visualizer.draw_schedule(schedule, img_path="/tmp/" + g.name + ".png")
+
+        return (peak_mem_usage, fragmentation, stop - start)
+
+    def run_rematerialization(self, g, memory_budget):
+        start = time.time()
+        s = training_graph_optimizer.Scheduler(g, rel_stop=0.01, timeout_s=1800)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            allow_swaps=False,
+            allow_rematerialization=True,
+            mem_limit=memory_budget,
+        )
+        stop = time.time()
+        extra_runtime = summary["rematerialization_time"]
+        model_runtime = 0
+        for n in g.nodes.values():
+            if not n.time:
+                continue
+            model_runtime += n.time
+        assert utils.validate_timeline(schedule)
+        assert summary["peak_mem_usage"] == summary["required_memory"]
+        assert summary["total_data_swapped"] == 0
+        return (extra_runtime / model_runtime, stop - start)
+
+    def run_spilling(self, g, memory_budget):
+        start = time.time()
+        s = training_graph_optimizer.Scheduler(g, rel_stop=0.01, timeout_s=1800)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            allow_swaps=True,
+            allow_rematerialization=False,
+            mem_limit=memory_budget,
+        )
+        stop = time.time()
+        # TODO: replace bytes swapped to actual estimate of how much time it takes to
+        # spill the data
+        extra_runtime = summary["total_data_swapped"] / 16.0e9
+        model_runtime = 0
+        for n in g.nodes.values():
+            if not n.time:
+                continue
+            model_runtime += n.time
+        # print(f"MODEL TIME {model_runtime} vs SPILLING TIME {extra_runtime}")
+        assert utils.validate_timeline(schedule)
+        assert summary["peak_mem_usage"] == summary["required_memory"]
+        return (extra_runtime / model_runtime, stop - start)
+
+
+BENCHMARKS = {
+    "alexnet": ["eval", "train"],
+    "bert": ["eval", "train"],
+    # "conformer": ["eval", "train"],  # fx can't trace the model
+    # "deeplab": ["eval"],  # Train mode doesn't load
+    "efficientnet": ["eval", "train"],
+    # "emformer": ["eval", "train"],  # fx can't trace the model
+    "googlenet": ["eval", "train"],
+    "inception": ["eval", "train"],
+    "mnasnet": ["eval", "train"],
+    "mobilenet": ["eval", "train"],
+    # "raft": ["eval", "train"],  # Model fails to load
+    "resnet": ["eval", "train"],
+    "resnet50": ["eval", "train"],
+    "resnet3d": ["eval", "train"],
+    "squeezenet": ["eval", "train"],
+    # "ssd": ["eval"],  # Needs target in train mode
+    # "swin": ["eval"],  # Model fails sanity checks
+    "transformer": ["eval", "train"],
+    "transformer_dflt": ["eval", "train"],
+    "vgg": ["eval", "train"],
+    "vgg16": ["eval", "train"],
+    "vgg19": ["eval", "train"],
+    "vit": ["eval", "train"],
+    "xlmr": ["eval", "train"],
+}
+
+
+import argparse
+
+parser = argparse.ArgumentParser(description="MemOpt Benchmarks")
+# fmt: off
+parser.add_argument("-b", "--batch-size", "--batch-sizes", nargs="+", type=int, default=[1, 32])
+parser.add_argument("-m", "--model", "--models", nargs="+", type=str, default=BENCHMARKS.keys())
+parser.add_argument("--mode", "--modes", nargs="+", type=str, choices=["eval", "train"], default=None)
+# fmt: on
+parser.add_argument("--generate-addresses", action="store_true")
+parser.add_argument("--rematerialization", action="store_true")
+parser.add_argument("--spilling", action="store_true")
+parser.add_argument("--render-models", action="store_true")
+parser.add_argument("--gpu-profile", action="store_true")
+parser.add_argument("--profile-alloc-time", action="store_true")
+parser.add_argument("--skip-simulation", action="store_true")
+parser.add_argument("--skip-node-ordering", action="store_true")
+parser.add_argument("--log-path", "--log_path", default="/tmp/opt4ml_benchmarks.csv")
+parser.add_argument("--append-log", action="store_true")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    print(f"Running with args {args}")
+
+    b = Benchmark()
+
+    results = []
+
+    for model in args.model:
+        modes = BENCHMARKS[model] if not args.mode else args.mode
+        for mode in modes:
+            for batch_size in args.batch_size:
+                result = OrderedDict(
+                    [("model", model), ("mode", mode), ("batch_size", batch_size)]
+                )
+                print(
+                    f"\nLOADING MODEL {model} IN {mode} MODE WITH BATCH SIZE {batch_size}",
+                    flush=True,
+                )
+                device = "cpu"
+                profile = []
+                warm_up_iters = 1
+                profile_iters = 10
+                if args.rematerialization or args.spilling or args.gpu_profile:
+                    profile.append("time")
+                if args.gpu_profile:
+                    torch.cuda.empty_cache()
+                    profile.append("memory")
+                    warm_up_iters = 0
+                    profile_iters = 300
+                    device = "cuda"
+
+                try:
+                    graph, pt_node_order = b.load_model(
+                        model,
+                        mode,
+                        batch_size,
+                        device=device,
+                        profile=profile,
+                        warm_up_iters=warm_up_iters,
+                        profile_iters=profile_iters,
+                        render_model=args.render_models,
+                    )
+                except Exception as e:
+                    print(f"  FAILED TO LOAD {model}, SKIPPING TO NEXT MODEL: {e}")
+                    result["load_model.error"] = str(e).replace("\n", " ")
+                    continue
+
+                print(
+                    f"BENCHMARKING MODEL {model} IN {mode} MODE WITH BATCH SIZE {batch_size}",
+                    flush=True,
+                )
+                if args.gpu_profile:
+                    print(
+                        f"PROFILED MAX MEMORY FRAGMENTATION IS {graph.max_mem_fragmentation*100}% AND PROFILED PEAK MEMORY IS {graph.peak_reserved_bytes/(2**30)} GB"
+                    )
+                    result[
+                        "profile.max_mem_fragmentation"
+                    ] = graph.max_mem_fragmentation
+                    result["profile.peak_reserved_bytes"] = graph.peak_reserved_bytes
+
+                if not args.skip_simulation:
+                    simulated_mem_usage, _ = b.run_simulation(
+                        graph,
+                        pt_node_order,
+                    )
+                    print(
+                        f"  SIMULATED PEAK MEM USAGE IS {simulated_mem_usage}",
+                        flush=True,
+                    )
+                    result["simulated_mem_usage"] = simulated_mem_usage
+
+                if args.profile_alloc_time:
+                    torch.cuda.empty_cache()
+                    runtime, alloc_count = b.measure_pt_alloc_time(pt_node_order)
+                    print(f"RAN {alloc_count} ALLOC/DEALLOC IN {runtime:.1f}s")
+                    print(
+                        f"AVERAGE TIME IS {1e6*runtime/alloc_count} USEC PER ALLOC/DEALLOC"
+                    )
+                    result["profile.alloc_runtime"] = runtime
+                    result["profile.alloc_count"] = alloc_count
+
+                if not args.skip_node_ordering:
+                    assert (
+                        not args.skip_simulation
+                    ), "Simulation is required to run node ordering"
+                    try:
+                        peak_mem_usage, node_ordering, runtime = b.run_node_ordering(
+                            graph
+                        )
+                        print(
+                            f"  REORDERED NODES IN {runtime:.1f}s. PEAK MEM USAGE WAS {peak_mem_usage} (SAVED {(simulated_mem_usage - peak_mem_usage) / simulated_mem_usage * 100:.1f}%)",
+                            flush=True,
+                        )
+                        result["node_ordering.runtime"] = runtime
+                        result["node_ordering.peak_mem_usage"] = peak_mem_usage
+                    except Exception as e:
+                        print(f"  FAILED TO REORDER NODES: {e}", flush=True)
+                        result["node_ordering.error"] = str(e).replace("\n", " ")
+                        continue
+
+                if args.generate_addresses:
+                    assert (
+                        not args.skip_simulation
+                    ), "Simulation is required to run address generation"
+                    assert (
+                        not args.skip_node_ordering
+                    ), "Node ordering is required to run address generation"
+                    try:
+                        (
+                            peak_mem_usage,
+                            fragmentation,
+                            runtime,
+                        ) = b.run_address_generation(graph, node_ordering)
+                        print(
+                            f"  GENERATED ADDRESSES IN {runtime:.1f}s. PEAK MEM USAGE WAS {peak_mem_usage}, FRAGMENTATION WAS {fragmentation * 100:.1f}%)",
+                            flush=True,
+                        )
+                        result["address_generation.runtime"] = runtime
+                        result["address_generation.fragmentation"] = fragmentation
+                        result["address_generation.peak_mem_usage"] = peak_mem_usage
+                    except Exception as e:
+                        print(f"  FAILED TO GENERATE ADDRESSES: {e}", flush=True)
+                        result["address_generation.error"] = str(e).replace("\n", " ")
+                        traceback.print_exc()
+
+                if args.rematerialization:
+                    assert (
+                        not args.skip_simulation
+                    ), "Simulation is required to run rematerialization"
+                    assert (
+                        not args.skip_node_ordering
+                    ), "Node ordering is required to run rematerialization"
+                    try:
+                        s = training_graph_optimizer.Scheduler(graph)
+                        min_memory, _ = s.ComputeMinimumMemoryRequired()
+                        for savings in [0.1, 0.25, 0.5, 0.75, 1.0]:
+                            done = False
+                            memory_budget = peak_mem_usage * (1.0 - savings)
+                            if memory_budget < min_memory:
+                                memory_budget = min_memory
+                                savings = 1.0 - memory_budget / peak_mem_usage
+                                done = True
+                            overhead, runtime = b.run_rematerialization(
+                                graph, memory_budget
+                            )
+                            print(
+                                f"  PLANNED REMATERIALIZATION TO SAVE {savings*100}% MEMORY IN {runtime:.1f}s. INCREASED MODEL LATENCY BY {overhead*100:.3f}%)",
+                                flush=True,
+                            )
+                            result[
+                                f"rematerialization.savings_{savings}.overhead"
+                            ] = overhead
+                            result[
+                                f"rematerialization.savings_{savings}.runtime"
+                            ] = runtime
+                            if done:
+                                break
+                    except Exception as e:
+                        print(
+                            f"  FAILED TO PLAN REMATERIALIZATION TO SAVE {savings*100}% MEMORY: {e}",
+                            flush=True,
+                        )
+                        result[f"rematerialization.savings_{savings}.error"] = str(
+                            e
+                        ).replace("\n", " ")
+                        traceback.print_exc()
+
+                if args.spilling:
+                    assert (
+                        not args.skip_simulation
+                    ), "Simulation is required to run spilling"
+                    assert (
+                        not args.skip_node_ordering
+                    ), "Node ordering is required to run address spilling"
+
+                    try:
+                        graph.constrain_relative_ordering(node_ordering, linearize=True)
+                        s = training_graph_optimizer.Scheduler(graph)
+                        min_memory, _ = s.ComputeMinimumMemoryRequired()
+                        for savings in [0.1, 0.25, 0.5, 0.75, 1.0]:
+                            done = False
+                            memory_budget = peak_mem_usage * (1.0 - savings)
+                            if memory_budget < min_memory:
+                                memory_budget = min_memory
+                                savings = 1.0 - memory_budget / peak_mem_usage
+                                done = True
+                            overhead, runtime = b.run_spilling(graph, memory_budget)
+                            print(
+                                f"  PLANNED SPILLING TO SAVE {savings*100}% MEMORY IN {runtime:.1f}s. INCREASED MODEL LATENCY BY {overhead*100:.3f}%)",
+                                flush=True,
+                            )
+                            result[f"spilling.savings_{savings}.overhead"] = overhead
+                            result[f"spilling.savings_{savings}.runtime"] = runtime
+                            if done:
+                                break
+                    except Exception as e:
+                        print(
+                            f"  FAILED TO PLAN SPILLING TO SAVE {savings*100}% MEMORY: {e}",
+                            flush=True,
+                        )
+                        result[f"spilling.savings_{savings}.error"] = str(e).replace(
+                            "\n", " "
+                        )
+                        traceback.print_exc()
+
+                # Log result
+                results.append(result)
+                pd.DataFrame(results).fillna("").to_csv(
+                    args.log_path,
+                    mode="a" if args.append_log else "w",
+                    header=not args.append_log,
+                    index=False,
+                )

--- a/benchmarks.sh
+++ b/benchmarks.sh
@@ -1,0 +1,124 @@
+#! /usr/bin/sh
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+set -o xtrace
+trap : SIGTERM SIGINT
+
+BENCHMARKS=(
+  "alexnet,eval,1"
+  "alexnet,eval,32"
+  "alexnet,train,1"
+  "alexnet,train,32"
+  "bert,eval,1"
+  "bert,eval,32"
+  "bert,train,1"
+  "bert,train,32"
+  #"conformer,eval,1"
+  #"conformer,eval,32"
+  #"conformer,train,1"
+  #"conformer,train,32"
+  #"deeplab,eval,1"
+  #"deeplab,eval,32"
+  #"deeplab,train,1"
+  #"deeplab,train,32"
+  "efficientnet,eval,1"
+  "efficientnet,eval,32"
+  "efficientnet,train,1"
+  "efficientnet,train,32"
+  #"emformer,eval,1"
+  #"emformer,eval,32"
+  #"emformer,train,1"
+  #"emformer,train,32"
+  "googlenet,eval,1"
+  "googlenet,eval,32"
+  "googlenet,train,1"
+  "googlenet,train,32"
+  "inception,eval,1"
+  "inception,eval,32"
+  "inception,train,1"
+  "inception,train,32"
+  "mnasnet,eval,1"
+  "mnasnet,eval,32"
+  "mnasnet,train,1"
+  "mnasnet,train,32"
+  "mobilenet,eval,1"
+  "mobilenet,eval,32"
+  "mobilenet,train,1"
+  "mobilenet,train,32"
+  #"raft,eval,1"
+  #"raft,eval,32"
+  #"raft,train,1"
+  #"raft,train,32"
+  "resnet,eval,1"
+  "resnet,eval,32"
+  "resnet,train,1"
+  "resnet,train,32"
+  "resnet50,eval,1"
+  "resnet50,eval,32"
+  "resnet50,train,1"
+  "resnet50,train,32"
+  "resnet3d,eval,1"
+  "resnet3d,eval,32"
+  "resnet3d,train,1"
+  "resnet3d,train,32"
+  "squeezenet,eval,1"
+  "squeezenet,eval,32"
+  "squeezenet,train,1"
+  "squeezenet,train,32"
+  #"ssd,eval,1"
+  #"ssd,eval,32"
+  #"ssd,train,1"
+  #"ssd,train,32"
+  #"swin,eval,1"
+  #"swin,eval,32"
+  #"swin,train,1"
+  #"swin,train,32"
+  "transformer,eval,1"
+  "transformer,eval,32"
+  "transformer,train,1"
+  "transformer,train,32"
+  "transformer_dflt,eval,1"
+  "transformer_dflt,eval,32"
+  "transformer_dflt,train,1"
+  "transformer_dflt,train,32"
+  "vgg,eval,1"
+  "vgg,eval,32"
+  "vgg,train,1"
+  "vgg,train,32"
+  "vgg16,eval,1"
+  "vgg16,eval,32"
+  "vgg16,train,1"
+  "vgg16,train,32"
+  "vgg19,eval,1"
+  "vgg19,eval,32"
+  "vgg19,train,1"
+  "vgg19,train,32"
+  "vit,eval,1"
+  "vit,eval,32"
+  "vit,train,1"
+  "vit,train,32"
+  "xlmr,eval,1"
+  "xlmr,eval,32"
+  "xlmr,train,1"
+  "xlmr,train,32"
+)
+
+first_time=1
+for benchmark in "${BENCHMARKS[@]}"; do
+  while IFS=',' read -r model mode batch_size; do
+    append_log=$([ "${first_time}" == 1 ] && echo || echo "--append-log")
+
+    python benchmarks.py -b "${batch_size}" --model "${model}" --mode "${mode}" ${append_log} &
+
+    # kill python run if user kills shell script, then terminate script
+    FIND_PID=$!
+    wait $FIND_PID
+    if [[ $? -gt 128 ]]
+    then
+        kill $FIND_PID
+        exit 1
+    fi
+
+    first_time=0
+  done <<< "${benchmark}"
+done

--- a/olla/acc_tracer/README.md
+++ b/olla/acc_tracer/README.md
@@ -1,0 +1,1 @@
+The acc_tracer directory was downloaded manually from: https://github.com/pytorch/TensorRT/tree/90b13a9c5fd8b062c4fc2d949aa446abc07cabed/py/torch_tensorrt/fx/tracer/acc_tracer

--- a/olla/acc_tracer/acc_normalizer.py
+++ b/olla/acc_tracer/acc_normalizer.py
@@ -1,0 +1,465 @@
+import inspect
+import logging
+import re
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Union
+
+import torch
+import torch.fx
+from torch.fx.node import _get_qualified_name
+
+from . import acc_utils
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+# Need to keep up-to-date with https://fburl.com/codesearch/7r2hhh53
+ALIAS_MAP = {
+    "input": ("input", "x", "a", "x1"),
+    "dim": ("dim", "axis"),
+    "keepdim": ("keepdim", "keepdims"),
+    "other": ("other", "x2"),
+}
+
+# Type used for arg replacement tuples. The list represents the argument signature of
+# some callable. Each item in the list is a tuple, where for each member of a tuple:
+# - The first member is union of either:
+#   - A tuple of all potential alias kwarg str names of the source signature, or
+#   - A tuple of a single str representing the single kwarg name allowed.
+# - The second member is the str name of the kwarg to map it to. This is either from the
+#   signature of the acc_op, or for custom mapped nodes from the original unnormalized op.
+# - The third member is a bool representing whether this arg is optional, i.e. whether it
+#   is allowed to not be present in the original input args.
+ArgReplacementTuplesType = List[Tuple[Tuple[str, ...], str, bool]]
+
+
+class NormalizationInfo(NamedTuple):
+    """
+    Holds normalization info for some FX node, where the FX node will be mapped either
+    via new_fn_target and arg_replacement_tuples, or via custom_mapping_fn.
+
+    If via new_fn_target and arg_replacement_tuples:
+      - new_fn_target is the target function to replace the original node with
+        (generally some function from acc_ops).
+
+      - arg_replacement_tuples describes how to map the original FX node's args/kwargs to
+        the new FX node. If set to None, then the kwargs are copied directly from the
+        original FX node. Else, this is list of three-member tuples, where each tuple
+        represents a mapping from either an arg or kwarg in the original FX node to the
+        kwarg it should be mapped to. If for ops registered with `register_acc_op` then
+        this is a mapping to the the new FX node for the acc_op. Otherwise it is for some
+        op registered with `register_custom_acc_mapper_fn`, in which case this is a
+        mapping for the original input node so its args are normalized to kwargs before
+        being custom normalized to acc_ops. The third member of the tuple is a bool
+        representing whether this argument is optional; if False and the arg is not
+        present then an assertion will be thrown. The index of the tuple indicates where
+        the original arg is in node.args and the string name indicates which original
+        kwarg it is.
+
+    If via custom_mapping_fn, then custom_mapping_fn is some function that takes the
+    original FX node as input and returns the FX node that should replace it. This means
+    it was registered via `register_custom_acc_mapper_fn`.
+    """
+
+    new_fn_target: Callable
+    arg_replacement_tuples: Optional[ArgReplacementTuplesType]
+    custom_mapping_fn: Optional[Callable]
+    # either (tensor_meta_field_name, original_field_name, move_to_qparams) or
+    # (tensor_meta_field_name, orginal_field_name)
+    # when move_to_qparams is True, we'll move the field to qparams
+    # dictionary, otherwise it will stay in TensorMeta itself
+    kwargs_to_move_to_acc_out_ty: Optional[
+        List[Union[Tuple[str, str, bool], Tuple[str, str]]]
+    ]
+    needs_shapes_for_normalization: bool
+
+
+# Dict from (op, target) to NormalizationInfo for that op.
+_normalization_dict: Dict[Tuple[str, Union[str, Callable]], NormalizationInfo] = {}
+
+# Set of all the acc ops.
+_acc_ops: Set[Callable] = set()
+
+
+def _insert_fun(
+    op_and_target: Tuple[str, Union[str, Callable]],
+    arg_replacement_tuples: List[Tuple],
+    new_fn_target: Optional[Callable] = None,
+    custom_mapping_fn: Optional[Callable] = None,
+    kwargs_to_move_to_acc_out_ty: Optional[
+        List[Union[Tuple[str, str, bool], Tuple[str, str]]]
+    ] = None,
+    needs_shapes_for_normalization=False,
+    allow_normalize_from_torch_package=False,
+):
+    if op_and_target[0] == "call_function":
+        assert callable(op_and_target[1])
+    elif op_and_target[0] == "call_method":
+        assert isinstance(op_and_target[1], str)
+    elif op_and_target[0] == "call_module":
+        assert isinstance(op_and_target[1], type)
+
+    # Finalize arg replacement tuples.
+    # 1. Check to see if they have the `is_optional` bool, and if not defaulting it to
+    #   False.
+    # 2. Some kwargs might have aliases. e.g. "a", "x" and "x1" are aliases of "input".
+    #   Here we replace `orig_kwarg` with a tuple of all aliases if it has aliases.
+    final_arg_replacement_tuples = []
+    for arg_replacement_tuple in arg_replacement_tuples:
+        if len(arg_replacement_tuple) == 2:
+            orig_kwarg, new_kwarg, is_optional = *arg_replacement_tuple, False
+        else:
+            assert len(arg_replacement_tuple) == 3
+            orig_kwarg, new_kwarg, is_optional = arg_replacement_tuple
+
+        if not isinstance(orig_kwarg, tuple):
+            orig_kwarg = (orig_kwarg,)
+
+        # Use set to avoid duplicates.
+        orig_kwarg_set = set(orig_kwarg)
+
+        for k in orig_kwarg:
+            if k in ALIAS_MAP:
+                orig_kwarg_set.update(ALIAS_MAP[k])
+        final_arg_replacement_tuples.append(
+            (tuple(orig_kwarg_set), new_kwarg, is_optional)
+        )
+
+    assert op_and_target not in _normalization_dict.keys()
+    norm_info = NormalizationInfo(
+        new_fn_target=new_fn_target,  # type: ignore[arg-type]
+        arg_replacement_tuples=final_arg_replacement_tuples,
+        custom_mapping_fn=custom_mapping_fn,
+        kwargs_to_move_to_acc_out_ty=kwargs_to_move_to_acc_out_ty,
+        needs_shapes_for_normalization=needs_shapes_for_normalization,
+    )
+    _normalization_dict[op_and_target] = norm_info
+
+    # If allow_normalize_from_torch_package then add another entry to
+    # _normalization_dict where we look for the qualified name of the target with the
+    # torch_package module prefix. Note that we leave off any integer at the end of
+    # "<torch_package_>" in order to allow for whatever mangling index is used.
+    if allow_normalize_from_torch_package:
+        torch_package_op_and_target = (
+            op_and_target[0],  # type: ignore[]
+            f"<torch_package_>.{_get_qualified_name(op_and_target[1])}",  # type: ignore[arg-type]
+        )
+        _normalization_dict[torch_package_op_and_target] = norm_info
+
+
+def _get_dup_signature_tuples(fn: Callable) -> List[Tuple[str, str]]:
+    """
+    Helper that inspects the arg signature of `fn` and returns a list of tuples, where
+    each tuple is a pair of duplicated names which is used for arg_replacement_tuples.
+    """
+    sig_tuples: List[Tuple[str, str]] = []
+    for param in inspect.signature(inspect.unwrap(fn)).parameters:
+        sig_tuples.append((param, param))
+    return sig_tuples
+
+
+def register_acc_op(acc_op: Callable):
+    """
+    For a new acc op, add this as decorator to register it.
+    """
+    _acc_ops.add(acc_op)
+    return acc_op
+
+
+def register_acc_op_mapping(
+    op_and_target: Tuple[str, Union[str, Callable]],
+    arg_replacement_tuples: Optional[
+        List[
+            Union[
+                Tuple[Union[str, Tuple[str, ...]], str],
+                Tuple[Union[str, Tuple[str, ...]], str, bool],
+            ]
+        ]
+    ] = None,
+    kwargs_to_move_to_acc_out_ty: Optional[
+        List[Union[Tuple[str, str, bool], Tuple[str, str]]]
+    ] = None,
+    allow_normalize_from_torch_package=False,
+):
+    """
+    Use this decorator to map a non-acc operator to an acc operator.
+
+    Args:
+        op_and_target: A tuple that contains op and target of the node that represents the non-acc operator.
+        arg_replacement_tuples: Please refer to the comment on above for `ArgReplacementTuplesType`.
+        kwargs_to_move_to_acc_out_ty: The kwargs we want to move out from the non-acc op kwargs to acc_out_ty.
+    """
+
+    def insert(new_fn_target: Callable):
+        # If arg_replacement_tuples is None then assume we use the same signature for
+        # the acc_op and the original op.
+        if arg_replacement_tuples is None:
+            final_arg_replacement_tuples = _get_dup_signature_tuples(new_fn_target)
+        else:
+            final_arg_replacement_tuples = arg_replacement_tuples  # type: ignore[assignment]
+
+        _insert_fun(
+            op_and_target=op_and_target,
+            new_fn_target=new_fn_target,
+            arg_replacement_tuples=final_arg_replacement_tuples,  # type: ignore[arg-type]
+            kwargs_to_move_to_acc_out_ty=kwargs_to_move_to_acc_out_ty,
+            allow_normalize_from_torch_package=allow_normalize_from_torch_package,
+        )
+        return new_fn_target
+
+    return insert
+
+
+def register_custom_acc_mapper_fn(
+    op_and_target: Tuple[str, Union[str, Callable]],
+    arg_replacement_tuples: List[
+        Union[
+            Tuple[Union[str, Tuple[str, ...]], str],
+            Tuple[Union[str, Tuple[str, ...]], str, bool],
+        ]
+    ],
+    needs_shapes_for_normalization=False,
+    allow_normalize_from_torch_package=False,
+):
+    def insert(custom_mapping_fn: Callable):
+        _insert_fun(
+            op_and_target=op_and_target,
+            custom_mapping_fn=custom_mapping_fn,
+            arg_replacement_tuples=arg_replacement_tuples,  # type: ignore[arg-type]
+            needs_shapes_for_normalization=needs_shapes_for_normalization,
+            allow_normalize_from_torch_package=allow_normalize_from_torch_package,
+        )
+        return custom_mapping_fn
+
+    return insert
+
+
+def move_kwargs_to_acc_out_ty(
+    node_or_normalization_info: Union[NormalizationInfo, torch.fx.Node],
+    new_kwargs: Dict[str, Any],
+):
+    """
+    Given `node_or_normalization_info` which is either NormalizationInfo for a node, or
+    a node to fetch NormalizationInfo for, check if kwargs_to_move_to_acc_out_ty exists
+    in the NormalizationInfo, and if so perform the move of kwargs to acc_out_ty.
+    """
+
+    if isinstance(node_or_normalization_info, torch.fx.Node):
+        node = node_or_normalization_info
+        normalization_info = _normalization_dict.get((node.op, node.target))
+    else:
+        assert isinstance(node_or_normalization_info, NormalizationInfo)
+        normalization_info = node_or_normalization_info
+
+    assert normalization_info is not None
+    if normalization_info.kwargs_to_move_to_acc_out_ty is None:
+        return
+
+    assert acc_utils.is_acc_op_with_kwarg(
+        normalization_info.new_fn_target, "acc_out_ty"
+    )
+
+    # Build a dict representing the new TensorMetadata to use for acc_out_ty,
+    # and then remove the kwarg from the new_kwargs since it's passed in via
+    # acc_out_ty instead.
+    tmd_dict: Dict[str, Any] = {}
+    qparams: Dict[str, Any] = {}
+
+    for kwarg_replacement_tuple in normalization_info.kwargs_to_move_to_acc_out_ty:
+        if len(kwarg_replacement_tuple) == 2:
+            orig_kwarg_name, tmd_field_name, move_to_qparams = *kwarg_replacement_tuple, False  # type: ignore[misc]
+        else:
+            assert len(kwarg_replacement_tuple) == 3
+            orig_kwarg_name, tmd_field_name, move_to_qparams = kwarg_replacement_tuple  # type: ignore[misc]
+        if move_to_qparams:
+            qparams[tmd_field_name] = new_kwargs[orig_kwarg_name]
+        else:
+            tmd_dict[tmd_field_name] = new_kwargs[orig_kwarg_name]
+        del new_kwargs[orig_kwarg_name]
+
+    tmd_dict["qparams"] = qparams
+    # Note: allow_partial_spec here because we are only using the tensor metadata tuple
+    # here to pass specific values into the function. For example, for quantization we
+    # only need to provide qparams dictionary, but is_quantized is
+    # not passed in.
+    new_kwargs["acc_out_ty"] = acc_utils.build_raw_tensor_meta(**tmd_dict)
+
+
+def get_normalized_kwargs(
+    node: torch.fx.Node, arg_replacement_tuples: ArgReplacementTuplesType
+):
+    new_kwargs = {}
+    final_arg_is_varg = False
+    for i, replacement_tuple in enumerate(arg_replacement_tuples):
+        orig_kwargs_names, new_kwarg_name, is_optional = replacement_tuple
+
+        # Check if this is a varg and if so break/process the rest outside the loop.
+        if "*" in orig_kwargs_names:
+            assert len(orig_kwargs_names) == 1
+            assert i == len(arg_replacement_tuples) - 1
+            final_arg_is_varg = True
+            break
+
+        # If nothing is found in node.kwargs it means the kwarg is in node.arg
+        # or it's optional. In this case, we set orig_kwargs_name to None.
+        assert isinstance(orig_kwargs_names, tuple)
+        orig_kwargs_name = next(
+            (key for key in orig_kwargs_names if key in node.kwargs),
+            None,
+        )
+
+        # If can't find in node.kwargs then it should be in the i index
+        # of node.args.
+        if orig_kwargs_name is None:
+            if i < len(node.args):
+                new_kwargs[new_kwarg_name] = node.args[i]
+            else:
+                # Verify the arg we're trying to normalize was optional.
+                assert (
+                    is_optional
+                ), f"Cannot normalize {orig_kwargs_names} to {new_kwarg_name} for {node.name}"
+        else:
+            new_kwargs[new_kwarg_name] = node.kwargs[orig_kwargs_name]
+
+    # If using var args then process the rest of the args now.
+    if final_arg_is_varg:
+        var_arg_idx = len(arg_replacement_tuples) - 1
+        new_kwarg_name = arg_replacement_tuples[var_arg_idx][1]
+        rest_of_args = []
+        for i in range(var_arg_idx, len(node.args)):
+            rest_of_args.append(node.args[i])
+        new_kwargs[new_kwarg_name] = rest_of_args
+
+    return new_kwargs
+
+
+def normalize(
+    mod: torch.fx.GraphModule,
+    expect_nodes_have_shapes: bool = False,
+    acc_normalization_block_list: Optional[
+        Set[Tuple[str, Union[str, Callable]]]
+    ] = None,
+):
+    assert len(_normalization_dict) > 0
+    graph = mod.graph
+    if acc_normalization_block_list is None:
+        acc_normalization_block_list = set()
+
+    # For "call_module" node we return _base_class_origin if it's a
+    # RewrittenModule, otherwise, return its type. For other nodes,
+    # we return node.target.
+    def get_target(mod: torch.fx.GraphModule, node: torch.fx.Node):
+        if node.op != "call_module":
+            return node.target
+
+        # Find the module that node.target points to
+        m = dict(mod.named_modules())[node.target]
+        return getattr(m, "_base_class_origin", type(m))
+
+    def normalize_to_acc_op(
+        node: torch.fx.Node,
+        normalization_info: NormalizationInfo,
+        normalized_args: Tuple[Any, ...],
+        normalized_kwargs: Dict[str, Any],
+    ):
+        # If there's a custom mapping function then use it.
+        if normalization_info.custom_mapping_fn is not None:
+            # For custom mapping, the normalized_kwargs are used for the original op,
+            # i.e. *before* custom acc_ops normalization. Do that now.
+            node.args = normalized_args
+            node.kwargs = normalized_kwargs
+            new_node = normalization_info.custom_mapping_fn(node, mod)
+            # If a new node is returned then use it to replace the old node. Otherwise
+            # the custom mapping function did its own replacement, so return early.
+            if new_node is None:
+                return
+        else:
+            # If there's kwargs_to_move_to_acc_out_ty then use it to setup acc_out_ty in
+            # normalized_kwargs, and remove the kwarg from normalized_kwargs.
+            move_kwargs_to_acc_out_ty(normalization_info, normalized_kwargs)
+
+            # All acc ops are functions. Create a call to the correct acc_ops target using
+            # the normalized kwargs provided.
+            with graph.inserting_before(node):
+                new_node = graph.create_node(
+                    "call_function",
+                    normalization_info.new_fn_target,
+                    args=normalized_args,
+                    kwargs=normalized_kwargs,
+                    name=node.name,
+                )
+                new_node.meta = node.meta.copy()
+
+        # Finally replace the original node with the normalized node.
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+
+        # Don't wrap the acc_op node just because the original node was wrapped.
+        if "is_wrapped" in new_node.meta:
+            del new_node.meta["is_wrapped"]
+
+    for node in graph.nodes:
+        if node.op in {"placeholder", "get_attr", "output"}:
+            continue
+
+        op_and_target = (node.op, get_target(mod, node))
+
+        if op_and_target in acc_normalization_block_list:
+            continue
+
+        normalization_info = _normalization_dict.get(op_and_target)
+
+        # Also check if the torch_packaged version of the op was specified to be normalized.
+        if normalization_info is None and node.op == "call_function":
+            # Strip off the mangle_index suffix here before checking the map.
+            target = re.sub(
+                r"\A<torch_package_\d+>",
+                "<torch_package_>",
+                _get_qualified_name(node.target),
+            )
+            torch_package_op_and_target = (node.op, target)
+            normalization_info = _normalization_dict.get(torch_package_op_and_target)
+
+        if normalization_info is None:
+            continue
+
+        # Get the normalized kwargs to be used by normalize_to_acc_op below. If
+        # normalization_info.arg_replacement_tuples is empty then assume the function
+        # signature must be left as is.
+        assert normalization_info.arg_replacement_tuples is not None
+        if len(normalization_info.arg_replacement_tuples) == 0:
+            normalized_args = node.args
+            normalized_kwargs = node.kwargs
+        else:
+            normalized_args = ()
+            try:
+                normalized_kwargs = get_normalized_kwargs(
+                    node, normalization_info.arg_replacement_tuples
+                )
+            except Exception:
+                _LOGGER.error(
+                    f"Error during kwarg normalization for: {node.format_node()}; "
+                    f"arg_replacement_tuples={normalization_info.arg_replacement_tuples}"
+                )
+                raise
+
+        if (
+            normalization_info.needs_shapes_for_normalization
+            and not expect_nodes_have_shapes
+        ):
+            # All nodes needing shapes for normalization should be custom mapped.
+            assert normalization_info.custom_mapping_fn is not None
+            # For custom mapping, the normalized_kwargs are used for the original op,
+            # i.e. *before* custom acc_ops normalization. Do that now so that whoever
+            # consumes the graph next (e.g. shape inference) can use kwargs safely.
+            node.args = normalized_args
+            node.kwargs = normalized_kwargs
+            continue
+
+        try:
+            normalize_to_acc_op(
+                node, normalization_info, normalized_args, normalized_kwargs
+            )
+        except Exception:
+            _LOGGER.error(f"Error during normalization for node: {node.format_node()}")
+            raise
+
+    # If there are any dead nodes left after normalization, eliminate them now.
+    mod.graph.eliminate_dead_code()

--- a/olla/acc_tracer/acc_op_properties.py
+++ b/olla/acc_tracer/acc_op_properties.py
@@ -1,0 +1,50 @@
+from collections import defaultdict
+from enum import auto, Flag
+from typing import Callable, DefaultDict, Set
+
+import torch
+import torch.fx
+
+
+class AccOpProperty(Flag):
+    """
+    A collection of static properties for acc_ops.
+
+    * pointwise - op commutes with data restructuring ops such as reshape,
+        transpose, permute. e.g. op(reshape(x)) == reshape(op(x)).
+        Alternatively, for tensor x = (x1, x2, ...), there exists a scalar
+        function f such that op(x) = (f(x1), f(x2), ...).
+    * quantized - op expects quantized inputs and return quantized outputs
+    * unary - op has exactly one graph dependent input. e.g. relu,
+        dequantize, sum
+    """
+
+    pointwise = auto()
+    quantized = auto()
+    unary = auto()
+
+
+acc_op_properties: DefaultDict[Callable, Set[AccOpProperty]] = defaultdict(set)
+acc_ops_with_property: DefaultDict[AccOpProperty, Set[Callable]] = defaultdict(set)
+
+
+def register_acc_op_properties(*properties: AccOpProperty):
+    """
+    Attach properties to acc_op to inform optimization
+    """
+
+    def decorator(acc_op: Callable):
+        acc_op_properties[acc_op] |= set(properties)
+        for prop in properties:
+            acc_ops_with_property[prop].add(acc_op)
+        return acc_op
+
+    return decorator
+
+
+def add_optimization_properties_to_meta(mod: torch.fx.GraphModule) -> None:
+    """
+    Add acc_op properties to Node.meta to inform optimization
+    """
+    for node in mod.graph.nodes:
+        node.meta["acc_op_properties"] = acc_op_properties[node.target]

--- a/olla/acc_tracer/acc_ops.py
+++ b/olla/acc_tracer/acc_ops.py
@@ -1,0 +1,3129 @@
+# encoding: utf-8
+import operator
+import warnings
+
+import torch  # isort:skip
+from typing import cast, Iterable, List, Sequence
+
+import torch.nn as nn
+from torch.fx.passes.shape_prop import _extract_tensor_metadata, TensorMetadata
+
+from . import acc_utils
+from .acc_normalizer import (
+    register_acc_op,
+    register_acc_op_mapping,
+    register_custom_acc_mapper_fn,
+)
+from .acc_op_properties import AccOpProperty, register_acc_op_properties
+
+this_arg_is_optional = True
+move_to_qparams = True
+dont_move_to_qparams = False
+
+# A proxy embedding size. We use this for tracing proxy operators using XL
+# weights which we can't load into memory (because they're too large), we
+# instead substitute a smaller weight with embedding size =
+# PROXY_EMBEDDING_SIZE.
+PROXY_EMBEDDING_SIZE = 8
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.linear))
+@register_acc_op
+def linear(*, input, weight, bias):
+    return nn.functional.linear(input=input, weight=weight, bias=bias)
+
+
+@register_acc_op_properties(AccOpProperty.quantized)
+@register_acc_op
+def quantized_linear(*, input, weight, bias, acc_out_ty=None):
+    assert acc_out_ty is not None
+    qparams = acc_out_ty.qparams
+    return nn.quantized.functional.linear(
+        input,
+        weight,
+        bias,
+        qparams["scale"],
+        qparams["zero_point"],
+    )
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "flatten"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("start_dim", "start_dim", this_arg_is_optional),
+        ("end_dim", "end_dim", this_arg_is_optional),
+    ],
+)
+@register_acc_op_mapping(op_and_target=("call_function", torch.flatten))
+@register_acc_op
+def flatten(*, input, start_dim=0, end_dim=-1):
+    return torch.flatten(input=input, start_dim=start_dim, end_dim=end_dim)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "squeeze"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.squeeze),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def squeeze(*, input, dim=None):
+    if dim is None:
+        return input.squeeze()
+    return input.squeeze(dim=dim)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.embedding))
+@register_acc_op
+def embedding(
+    *,
+    input,
+    weight,
+    padding_idx,
+    max_norm,
+    norm_type,
+    scale_grad_by_freq,
+    sparse,
+):
+    return torch.nn.functional.embedding(**locals())
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.max_pool1d))
+@register_acc_op
+def max_pool1d(
+    *,
+    input,
+    kernel_size,
+    stride,
+    padding,
+    dilation,
+    ceil_mode,
+    return_indices,
+):
+    return nn.functional.max_pool1d(
+        input=input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=return_indices,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.max_pool2d))
+@register_acc_op
+def max_pool2d(
+    *,
+    input,
+    kernel_size,
+    stride,
+    padding,
+    dilation,
+    ceil_mode,
+    return_indices,
+):
+    return nn.functional.max_pool2d(
+        input=input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=return_indices,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.max_pool3d))
+@register_acc_op
+def max_pool3d(
+    *, input, kernel_size, stride, padding, dilation, ceil_mode, return_indices
+):
+    return nn.functional.max_pool3d(
+        input=input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        return_indices=return_indices,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", nn.functional.adaptive_avg_pool2d)
+)
+@register_acc_op
+def adaptive_avg_pool2d(*, input, output_size):
+    return nn.functional.adaptive_avg_pool2d(input=input, output_size=output_size)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", nn.functional.adaptive_avg_pool3d)
+)
+@register_acc_op
+def adaptive_avg_pool3d(*, input, output_size):
+    return nn.functional.adaptive_avg_pool3d(input=input, output_size=output_size)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.avg_pool1d))
+@register_acc_op
+def avg_pool1d(
+    *,
+    input,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+):
+    return nn.functional.avg_pool1d(
+        input=input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.avg_pool2d))
+@register_acc_op
+def avg_pool2d(
+    *,
+    input,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+):
+    return nn.functional.avg_pool2d(
+        input=input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        divisor_override=divisor_override,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.avg_pool3d))
+@register_acc_op
+def avg_pool3d(
+    *,
+    input,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+):
+    return nn.functional.avg_pool3d(
+        input=input,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        divisor_override=divisor_override,
+    )
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.sign))
+@register_acc_op
+def sign(*, input):
+    return torch.sign(input)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "type"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+def custom_type_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    input_obj = node.kwargs["input"]
+    dtype_obj = node.kwargs.get("dtype")
+    with node.graph.inserting_before(node):
+        if dtype_obj == None:
+            dtype_node = node.graph.call_function(dtype, kwargs={"input": input_obj})
+            dtype_node.meta["type"] = torch.dtype
+            return dtype_node
+        else:
+            new_kwargs = {
+                "input": input_obj,
+                "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=dtype_obj),
+            }
+            new_node = node.graph.call_function(to_dtype, kwargs=new_kwargs)
+            new_node.meta = node.meta
+            return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "type_as"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("tensor", "tensor"),
+    ],
+)
+def custom_type_as_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    input_obj = node.kwargs["input"]
+    other_obj = node.kwargs["tensor"]
+    with node.graph.inserting_before(node):
+        dtype_node = node.graph.call_function(dtype, kwargs={"input": other_obj})
+        dtype_node.meta["type"] = torch.dtype
+        device_node = node.graph.call_function(device, kwargs={"input": other_obj})
+        device_node.meta["type"] = torch.device
+
+        new_kwargs = {
+            "input": input_obj,
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=dtype_node),
+            "device": device_node,
+        }
+        new_node = node.graph.call_function(to_dtype, kwargs=new_kwargs)
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def dtype(*, input):
+    return input.dtype
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def size(*, input):
+    return input.size()
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def device(*, input):
+    return input.device
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.numel))
+@register_acc_op
+def numel(*, input):
+    return torch.numel(input)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", getattr),
+    arg_replacement_tuples=[],
+)
+def custom_getattr_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Custom function for mapping a call_function getattr to other ops.
+
+    Supports:
+    * getattr on a torch.Tensor with "shape", "device", or "dtype" attributes
+    * getattr for accessing named tuples
+    """
+    # Have to use args here since getattr forces positional args.
+    input_obj = node.args[0]
+    attr_name = node.args[1]
+    assert isinstance(input_obj, torch.fx.Node)
+    input_obj_type = input_obj.meta["type"]
+
+    # Handle named tuple access. NamedTupleMeta and the namedtuple factory function
+    # create a subclass of tuple with an extra _fields attribute.
+    if issubclass(input_obj_type, tuple) and hasattr(input_obj_type, "_fields"):
+        idx = None
+        for i, name in enumerate(input_obj_type._fields):
+            if name == attr_name:
+                idx = i
+                break
+        assert (
+            idx is not None
+        ), f"Named tuple type {input_obj_type} does not have field {name}"
+
+        with node.graph.inserting_before(node):
+            getitem_node = node.graph.call_function(
+                getitem, kwargs={"input": input_obj, "idx": idx}
+            )
+            getitem_node.meta = node.meta.copy()
+            return getitem_node
+
+    assert (
+        input_obj_type == torch.Tensor
+    ), f"Expected torch.Tensor type for {input_obj_type}"
+    assert (
+        attr_name == "shape" or attr_name == "device" or attr_name == "dtype"
+    ), f"Only supporting shape, device and dtype getattr for now, not {attr_name}"
+    if attr_name == "shape":
+        func = size
+    elif attr_name == "device":
+        func = device
+    elif attr_name == "dtype":
+        func = dtype
+    with node.graph.inserting_before(node):
+        size_node = node.graph.call_function(func, kwargs={"input": input_obj})
+        size_node.meta = node.meta.copy()
+        return size_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "size"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+    ],
+)
+def tensor_size_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Mapping from Tensor.size() to acc_ops.size. We map size() to acc_ops.size directly
+    and map size(dim) to acc_ops.size + acc_ops.getitem.
+    """
+
+    with node.graph.inserting_before(node):
+        size_node = node.graph.call_function(
+            size, kwargs={"input": node.kwargs["input"]}
+        )
+
+        if "dim" not in node.kwargs:
+            size_node.meta = node.meta.copy()
+            return size_node
+
+        size_node.meta["type"] = torch.Size
+        getitem_node = node.graph.call_function(
+            getitem, kwargs={"input": size_node, "idx": node.kwargs["dim"]}
+        )
+        getitem_node.meta = node.meta.copy()
+        return getitem_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.add))
+@register_acc_op_mapping(op_and_target=("call_method", "add"))
+@register_acc_op
+def add(*, input, other):
+    return input + other
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_method", "unsqueeze"))
+@register_acc_op_mapping(op_and_target=("call_function", torch.unsqueeze))
+@register_acc_op
+def unsqueeze(*, input, dim):
+    return torch.unsqueeze(input=input, dim=dim)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_method", "tile"))
+@register_acc_op_mapping(op_and_target=("call_function", torch.tile))
+@register_acc_op
+def tile(*, input, dims):
+    return torch.tile(input=input, dims=dims)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "repeat"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("*", "sizes"),
+    ],
+)
+def repeat_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Map repeat to tile.
+    """
+    with node.graph.inserting_before(node):
+        inputs = node.kwargs["input"]
+        dims = node.kwargs["sizes"]
+        new_node = node.graph.create_node(
+            "call_function",
+            tile,
+            kwargs={"input": inputs, "dims": dims},
+            name=f"{node.name}_repeat_map",
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "repeat_interleave"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("repeats", "repeats"),
+        ("dim", "dim", this_arg_is_optional),
+        ("output_size", "output_size", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.repeat_interleave),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("repeats", "repeats"),
+        ("dim", "dim", this_arg_is_optional),
+        ("output_size", "output_size", this_arg_is_optional),
+    ],
+)
+def repeat_interleave_mapper(node: torch.fx.Node, _: nn.Module):
+    input_node = node.kwargs["input"]
+    repeats = cast(int, node.kwargs["repeats"])
+    dim = node.kwargs["dim"]
+    assert (
+        type(repeats) is int
+    ), "We currently only support `repeat_interleave` with int repeats"
+    rank = node.meta["tensor_rank"]
+    if dim is None:
+        repeat_dim = rank - 1
+    else:
+        assert type(dim) is int, "dim should be an int"
+        repeat_dim = dim
+    tile_dims = [1] * (rank + 1)
+    tile_dims[repeat_dim + 1] = repeats
+
+    with node.graph.inserting_before(node):
+        unsqueeze_node = node.graph.create_node(
+            "call_function",
+            unsqueeze,
+            kwargs={"input": input_node, "dim": repeat_dim + 1},
+            name=f"{node.name}_unsqueeze",
+        )
+        tile_node = node.graph.create_node(
+            "call_function",
+            tile,
+            kwargs={"input": unsqueeze_node, "dims": tuple(tile_dims)},
+            name=f"{node.name}_repeat_interleave_map_tile",
+        )
+        new_shape = []
+        if dim is not None:
+            if dim < 0:
+                repeat_dim = dim + rank
+            else:
+                repeat_dim = dim
+            size_node = node.graph.create_node(
+                "call_function",
+                size,
+                kwargs={"input": input_node},
+                name=f"{node.name}_size",
+            )
+            size_node.meta["type"] = torch.Size
+            for i in range(rank):
+                shape_i = node.graph.create_node(
+                    "call_function",
+                    getitem,
+                    kwargs={"input": size_node, "idx": i},
+                    name=f"{node.name}_size_{i}",
+                )
+                if i == repeat_dim:
+                    new_shape.append(-1)
+                else:
+                    new_shape.append(shape_i)
+        else:
+            new_shape.append(-1)
+
+        reshaped_node = node.graph.create_node(
+            "call_function",
+            reshape,
+            kwargs={
+                "input": tile_node,
+                "acc_out_ty": acc_utils.build_raw_tensor_meta(shape=new_shape),
+            },
+            name=f"{node.name}_reshape",
+        )
+        reshaped_node.meta = node.meta.copy()
+        return reshaped_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.stack),
+    arg_replacement_tuples=[
+        ("tensors", "tensors"),
+        ("dim", "dim"),
+    ],
+)
+def stack_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Map torch.stack to unsqueeze + cat.
+    """
+    with node.graph.inserting_before(node):
+        inputs = node.kwargs["tensors"]
+        unsqueeze_nodes = []
+        assert isinstance(inputs, Sequence)
+        for i, t in enumerate(inputs):
+            new_node = node.graph.create_node(
+                "call_function",
+                unsqueeze,
+                kwargs={"input": t, "dim": node.kwargs["dim"]},
+                name=f"{node.name}_unsqueeze_{i}",
+            )
+            new_node.meta["type"] = torch.Tensor
+            unsqueeze_nodes.append(new_node)
+        cat_node = node.graph.create_node(
+            "call_function",
+            cat,
+            kwargs={"tensors": unsqueeze_nodes, "dim": node.kwargs["dim"]},
+        )
+        cat_node.meta = node.meta.copy()
+        return cat_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.clamp))
+@register_acc_op_mapping(op_and_target=("call_function", torch.clip))
+@register_acc_op_mapping(op_and_target=("call_method", "clamp"))
+@register_acc_op_mapping(op_and_target=("call_method", "clip"))
+@register_acc_op
+def clamp(*, input, min=None, max=None):
+    return torch.clamp(input=input, min=min, max=max)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.cat))
+@register_acc_op
+def cat(*, tensors, dim):
+    return torch.cat(tensors=tensors, dim=dim)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.transpose),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim0", "dim0"),
+        ("dim1", "dim1"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "transpose"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim0", "dim0"),
+        ("dim1", "dim1"),
+    ],
+)
+def transpose_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    # Get the dim-permutation/shuffle
+    ranks = node.meta["tensor_rank"]
+    shuffle = list(range(ranks))
+    dim0 = cast(int, node.kwargs["dim0"])
+    dim1 = cast(int, node.kwargs["dim1"])
+    shuffle[dim0] = dim1
+    shuffle[dim1] = dim0
+
+    # Create the new acc_ops.permute node. Update all uses of the transpose
+    # node and then delete the transpose node.
+    with node.graph.inserting_after(node):
+        permute_node = node.graph.call_function(
+            the_function=permute,
+            kwargs={
+                "input": node.kwargs.get("input"),
+                "permutation": shuffle,
+            },
+        )
+        permute_node.meta = node.meta.copy()
+        node.replace_all_uses_with(permute_node)
+
+    permute_node.graph.erase_node(node)
+    return permute_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_method", "contiguous"))
+@register_acc_op
+def contiguous(*, input):
+    return input.contiguous()
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "softmax"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.nn.functional.softmax),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def softmax(*, input, dim, dtype=None):
+    """
+    _stacklevel are ignored here.
+    """
+    return torch.nn.functional.softmax(input=input, dim=dim, dtype=dtype)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.addmm),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mat1", "mat1"),
+        ("mat2", "mat2"),
+        ("beta", "beta"),
+        ("alpha", "alpha"),
+    ],
+)
+def addmm_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Mapping from torch.addmm to acc_ops.mm -> acc_ops.add, if alpha or beta is not 1
+    then we also insert acc_ops.mul to the right place.
+    """
+    with node.graph.inserting_before(node):
+        mm_kwargs = {"input": node.kwargs["mat1"], "other": node.kwargs["mat2"]}
+        mm_node = node.graph.create_node(
+            "call_function", matmul, kwargs=mm_kwargs, name=f"{node.name}_mm"
+        )
+        mm_node.meta = node.meta.copy()
+
+        if node.kwargs["alpha"] != 1:
+            mul_kwargs = {"input": mm_node, "other": node.kwargs["alpha"]}
+            mm_node = node.graph.create_node(
+                "call_function", mul, kwargs=mul_kwargs, name=f"{mm_node.name}_mul"
+            )
+        mm_node.meta = node.meta.copy()
+
+        input_node = node.kwargs["input"]
+        if node.kwargs["beta"] != 1:
+            mul_kwargs = {"input": input_node, "other": node.kwargs["beta"]}
+            new_input_node = node.graph.create_node(
+                "call_function", mul, kwargs=mul_kwargs, name=f"{node.name}_input_mul"
+            )
+            assert isinstance(input_node, torch.fx.Node)
+            new_input_node.meta = input_node.meta.copy()
+            input_node = new_input_node
+
+        add_kwargs = {"input": mm_node, "other": input_node}
+        add_node = node.graph.create_node(
+            "call_function", add, kwargs=add_kwargs, name=f"{node.name}_add"
+        )
+        add_node.meta = node.meta.copy()
+        return add_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.t),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "t"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def t_mapper(node: torch.fx.Node, _: nn.Module):
+    ranks = node.meta["tensor_rank"]
+    shuffle = [1, 0] if (ranks > 1) else [0]
+
+    with node.graph.inserting_before(node):
+        new_node = node.graph.create_node(
+            "call_function",
+            permute,
+            kwargs={"input": node.kwargs["input"], "permutation": shuffle},
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "permute"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("*", "permutation"),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.permute),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dims", "permutation"),
+    ],
+)
+@register_acc_op
+def permute(*, input, permutation):
+    return input.permute(*permutation)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.square),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def square_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    input_node = node.kwargs["input"]
+    with node.graph.inserting_before(node):
+        new_node = node.graph.call_function(
+            mul, kwargs={"input": input_node, "other": input_node}
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_method", "mm"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mat2", "other"),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_function", operator.matmul),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mat2", "other"),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.bmm),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mat2", "other"),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.mm),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mat2", "other"),
+    ],
+)
+@register_acc_op_mapping(op_and_target=("call_function", torch.matmul))
+@register_acc_op
+def matmul(*, input, other):
+    return torch.matmul(input=input, other=other)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", nn.functional.dropout),
+    arg_replacement_tuples=[("input", "input")],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "detach"), arg_replacement_tuples=[("input", "input")]
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.detach),
+    arg_replacement_tuples=[("input", "input")],
+)
+def dropout_mapper(node: torch.fx.Node, mod: nn.Module):
+    """
+    Remove dropout node and directly map its input to output.
+    """
+    return node.kwargs["input"]
+
+
+try:
+    from torchvision.ops import stochastic_depth
+
+    assert callable(stochastic_depth)
+except Exception as e:
+    warnings.warn(
+        f"Unable to import torchvision related libraries.: {e}. Please install torchvision lib in order to lower stochastic_depth"
+    )
+else:
+
+    @register_custom_acc_mapper_fn(
+        op_and_target=("call_function", stochastic_depth),
+        arg_replacement_tuples=[("input", "input")],
+    )
+    def stochastic_depth_mapper(node: torch.fx.Node, mod: nn.Module):
+        """
+        Remove dropout node and directly map its input to output.
+        """
+        return node.kwargs["input"]
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_function", nn.functional.hardtanh),
+)
+@register_acc_op
+def hardtanh(*, input, min_val=-1.0, max_val=1.0):
+    return nn.functional.hardtanh(input=input, min_val=min_val, max_val=max_val)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.hardsigmoid))
+@register_acc_op
+def hardsigmoid(*, input):
+    return nn.functional.hardsigmoid(input)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", nn.functional.silu),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def silu(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    input_node = node.kwargs["input"]
+    with node.graph.inserting_before(node):
+        sigmoid_node = node.graph.call_function(sigmoid, kwargs={"input": input_node})
+        sigmoid_node.meta = node.meta.copy()
+        new_node = node.graph.call_function(
+            mul, kwargs={"input": sigmoid_node, "other": input_node}
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", nn.functional.hardswish),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def hardswish_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    input_node = node.kwargs["input"]
+    with node.graph.inserting_before(node):
+        new_sigmoid_node = node.graph.call_function(
+            hardsigmoid, kwargs={"input": input_node}
+        )
+        new_sigmoid_node.meta = node.meta.copy()
+        new_node = node.graph.call_function(
+            mul, kwargs={"input": new_sigmoid_node, "other": input_node}
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.quantized)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.ops.quantized.add),
+    arg_replacement_tuples=[
+        ("qa", "input"),
+        ("qb", "other"),
+        ("scale", "scale"),
+        ("zero_point", "zero_point"),
+    ],
+    kwargs_to_move_to_acc_out_ty=[
+        ("scale", "scale", move_to_qparams),
+        ("zero_point", "zero_point", move_to_qparams),
+    ],
+)
+@register_acc_op
+def quantized_add(*, input, other, acc_out_ty=None):
+    assert acc_out_ty is not None
+    qparams = acc_out_ty.qparams
+    return torch.ops.quantized.add(
+        input,
+        other,
+        qparams["scale"],
+        qparams["zero_point"],
+    )
+
+
+@register_acc_op_properties(AccOpProperty.quantized)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.ops.quantized.mul),
+    arg_replacement_tuples=[
+        ("qa", "input"),
+        ("qb", "other"),
+        ("scale", "scale"),
+        ("zero_point", "zero_point"),
+    ],
+    kwargs_to_move_to_acc_out_ty=[
+        ("scale", "scale", move_to_qparams),
+        ("zero_point", "zero_point", move_to_qparams),
+    ],
+)
+@register_acc_op
+def quantized_mul(*, input, other, acc_out_ty=None):
+    assert acc_out_ty is not None
+    qparams = acc_out_ty.qparams
+    return torch.ops.quantized.mul(
+        input,
+        other,
+        qparams["scale"],
+        qparams["zero_point"],
+    )
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_properties(AccOpProperty.quantized)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.quantize_per_tensor),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("scale", "scale"),
+        ("zero_point", "zero_point"),
+        ("dtype", "dtype"),
+    ],
+    kwargs_to_move_to_acc_out_ty=[
+        ("scale", "scale", move_to_qparams),
+        ("zero_point", "zero_point", move_to_qparams),
+        ("dtype", "dtype", dont_move_to_qparams),
+    ],
+)
+@register_acc_op
+def quantize_per_tensor(*, input, acc_out_ty=None):
+    assert acc_out_ty is not None
+    qparams = acc_out_ty.qparams
+    dtype = acc_out_ty.dtype
+    return torch.quantize_per_tensor(
+        input, qparams["scale"], qparams["zero_point"], dtype
+    )
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.quantize_per_channel),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("scales", "scales"),
+        ("zero_points", "zero_points"),
+        ("axis", "axis"),
+        ("dtype", "dtype"),
+    ],
+    kwargs_to_move_to_acc_out_ty=[
+        ("scales", "scale", move_to_qparams),
+        ("zero_points", "zero_point", move_to_qparams),
+        ("axis", "axis", move_to_qparams),
+        ("dtype", "dtype", dont_move_to_qparams),
+    ],
+)
+@register_acc_op
+def quantize_per_channel(*, input, acc_out_ty=None):
+    assert acc_out_ty is not None
+    qparams = acc_out_ty.qparams
+    dtype = acc_out_ty.dtype
+    return torch.quantize_per_channel(
+        input,
+        torch.tensor(qparams["scale"]),
+        torch.tensor(qparams["zero_point"]),
+        qparams["axis"],
+        dtype,
+    )  # type: ignore[call-overload]
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_method", "dequantize"))
+@register_acc_op_mapping(op_and_target=("call_function", torch.dequantize))
+@register_acc_op
+def dequantize(*, input):
+    return torch.dequantize(input)
+
+
+@register_acc_op_properties(
+    AccOpProperty.pointwise, AccOpProperty.unary, AccOpProperty.quantized
+)
+@register_acc_op
+def rescale_quantize_per_tensor(*, input, acc_out_ty=None):
+    assert acc_out_ty is not None
+    d = dequantize(input=input)
+    return quantize_per_tensor(input=d, acc_out_ty=acc_out_ty)
+
+
+@register_acc_op_properties(AccOpProperty.unary, AccOpProperty.quantized)
+@register_acc_op
+def rescale_quantize_per_channel(*, input, acc_out_ty=None):
+    assert acc_out_ty is not None
+    d = dequantize(input=input)
+    return quantize_per_channel(input=d, acc_out_ty=acc_out_ty)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.sub))
+@register_acc_op_mapping(op_and_target=("call_function", operator.sub))
+@register_acc_op_mapping(op_and_target=("call_method", "sub"))
+@register_acc_op
+def sub(*, input, other):
+    return input - other
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.mul))
+@register_acc_op_mapping(op_and_target=("call_function", operator.mul))
+@register_acc_op_mapping(op_and_target=("call_method", "mul"))
+@register_acc_op
+def mul(*, input, other):
+    return input * other
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "div"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+        ("rounding_mode", "rounding_mode", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.div),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+        ("rounding_mode", "rounding_mode", this_arg_is_optional),
+    ],
+)
+def div_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    with node.graph.inserting_before(node):
+        div_kwargs = dict(node.kwargs)
+        if "rounding_mode" not in div_kwargs or div_kwargs["rounding_mode"] is None:
+            div_node = node.graph.call_function(
+                div, kwargs={"input": div_kwargs["input"], "other": div_kwargs["other"]}
+            )
+        elif div_kwargs["rounding_mode"] == "trunc":
+            div_node = node.graph.call_function(
+                trunc_div,
+                kwargs={"input": div_kwargs["input"], "other": div_kwargs["other"]},
+            )
+        elif div_kwargs["rounding_mode"] == "floor":
+            div_node = node.graph.call_function(
+                floor_div,
+                kwargs={"input": div_kwargs["input"], "other": div_kwargs["other"]},
+            )
+        else:
+            raise RuntimeError(
+                f"Unhandled div rounding mode {div_kwargs['rounding_mode']}"
+            )
+        div_node.meta = node.meta.copy()
+        return div_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.truediv))
+@register_acc_op
+def div(*, input, other):
+    return input / other
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.floordiv))
+@register_acc_op
+def floor_div(*, input, other):
+    # This is temp fix because currently operator.floor_div for tensors would
+    # traslate into torch.floor_divide which would throw an error. After it's
+    # fixed we can stick to `input // other`.
+    if isinstance(input, torch.Tensor) or isinstance(other, torch.Tensor):
+        return torch.div(input, other, rounding_mode="floor")
+    return input // other
+
+
+# torch.floor_divide rounds result toward zero, rather than -Inf.
+# https://github.com/pytorch/pytorch/issues/43874
+@register_acc_op_mapping(op_and_target=("call_function", torch.floor_divide))
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op
+def trunc_div(*, input, other):
+    return torch.div(input, other, rounding_mode="trunc")
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.pow))
+@register_acc_op_mapping(op_and_target=("call_method", "pow"))
+@register_acc_op
+def pow(*, input, exponent):
+    return torch.pow(input, exponent)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.relu))
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.relu),
+    arg_replacement_tuples=[("input", "input")],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "relu"),
+    arg_replacement_tuples=[("input", "input")],
+)
+@register_acc_op
+def relu(*, input, inplace=False):
+    return nn.functional.relu(input=input, inplace=inplace)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.nn.functional.leaky_relu)
+)
+@register_acc_op
+def leaky_relu(*, input, negative_slope=0.01, inplace=False):
+    return nn.functional.leaky_relu(
+        input=input, negative_slope=negative_slope, inplace=inplace
+    )
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.elu))
+@register_acc_op
+def elu(*, input, alpha=1.0, inplace=False):
+    return nn.functional.elu(input=input, alpha=alpha, inplace=inplace)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.selu))
+@register_acc_op
+def selu(*, input, inplace=False):
+    return nn.functional.selu(input=input, inplace=inplace)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.softsign))
+@register_acc_op
+def softsign(*, input):
+    return nn.functional.softsign(input=input)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.log1p),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def torch_log1p_mapper(node: torch.fx.Node, _: torch.nn.Module) -> torch.fx.Node:
+    with node.graph.inserting_before(node):
+        add_kwargs = {"input": node.kwargs["input"], "other": 1.0}
+        add_node = node.graph.call_function(add, kwargs=add_kwargs)
+        add_node.meta = node.meta.copy()
+        log_kwargs = {"input": add_node}
+        log_node = node.graph.call_function(log, kwargs=log_kwargs)
+        log_node.meta = node.meta.copy()
+        return log_node
+
+
+def reduce_op_mapper(
+    node: torch.fx.Node, mod: torch.fx.GraphModule, func
+) -> torch.fx.Node:
+    with node.graph.inserting_before(node):
+        kwargs = dict(node.kwargs)
+        if "dim" in kwargs and isinstance(kwargs["dim"], int):
+            kwargs["dim"] = (kwargs["dim"],)
+        new_node = node.graph.call_function(func, kwargs=kwargs)
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def sum(*, input, dim=None, keepdim=False, dtype=None):
+    if dim is not None:
+        return torch.sum(input, dim=dim, keepdim=keepdim, dtype=dtype)
+    else:
+        return input.sum(dtype=dtype)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "sum"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.sum),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+def sum_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    return reduce_op_mapper(node, mod, sum)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def prod(*, input, dim=None, keepdim=False, dtype=None):
+    if dim is not None:
+        return torch.prod(input, dim=dim, keepdim=keepdim, dtype=dtype)
+    else:
+        return input.prod(dtype=dtype)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "prod"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.prod),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+def prod_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    func = prod
+    with node.graph.inserting_before(node):
+        kwargs = dict(node.kwargs)
+        new_node = node.graph.call_function(func, kwargs=kwargs)
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def mean(*, input, dim=None, keepdim=False, dtype=None):
+    if dim is not None:
+        return torch.mean(input, dim=dim, keepdim=keepdim, dtype=dtype)
+    else:
+        return input.mean(dtype=dtype)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "mean"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.mean),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+def mean_mapper(node, mod):
+    return reduce_op_mapper(node, mod, mean)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "std"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("unbiased", "unbiased", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.std),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("unbiased", "unbiased", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+def std_mapper(node, mod):
+    """
+    Formula of std: sqrt(sum(pow(X-mean(X))))/N)
+    This op is mapped to a few existing ops
+    """
+    input_node = node.kwargs["input"]
+    # unbiased = node.kwargs.get("unbiased")
+    dim = node.kwargs.get("dim")
+    keepdim = node.kwargs.get("keepdim")
+    # assert unbiased is False or unbiased is None, "We currently do not support `std` with unbiased=True where n-1 is used"
+    assert (
+        dim is not None and keepdim is not None
+    ), "We currently do not support `std` with dim=None and keepdim=None"
+
+    with node.graph.inserting_before(node):
+        # mean(X)
+        mean_kwargs = {
+            "input": input_node,
+            "dim": dim,
+            "keepdim": keepdim,
+        }
+        mean_node = node.graph.call_function(mean, kwargs=mean_kwargs)
+        mean_node.meta["type"] = torch.Tensor
+        # X-mean(X)
+        sub_kwargs = {
+            "input": input_node,
+            "other": mean_node,
+        }
+        sub_node = node.graph.call_function(sub, kwargs=sub_kwargs)
+        sub_node.meta["type"] = torch.Tensor
+        # pow(X-mean(X))
+        pow_kwargs = {
+            "input": sub_node,
+            "exponent": 2.0,
+        }
+        pow_node = node.graph.call_function(pow, kwargs=pow_kwargs)
+        pow_node.meta["type"] = torch.Tensor
+        # sum(pow(X-mean(X))))/N
+        post_mean_kwargs = {
+            "input": pow_node,
+            "dim": dim,
+            "keepdim": keepdim,
+        }
+        post_mean_node = node.graph.call_function(mean, kwargs=post_mean_kwargs)
+        post_mean_node.meta["type"] = torch.Tensor
+        # sqrt(sum(pow(X-mean(X))))/N)
+        sqrt_kwargs = {
+            "input": post_mean_node,
+        }
+        sqrt_node = node.graph.call_function(sqrt, kwargs=sqrt_kwargs)
+        sqrt_node.meta["type"] = torch.Tensor
+
+        output_node = sqrt_node
+        output_node.meta = node.meta.copy()
+        return output_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "max"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.max),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "min"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.min),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("dim", "other"), "dim_or_other", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+def add_maximum_minimum_mapper(
+    node: torch.fx.Node, mod: torch.fx.GraphModule
+) -> torch.fx.Node:
+    # there are effectively three versions of torch.max / torch.min
+    # full reduce: torch.max(input) -> Tensor
+    # dimensional reduce: torch.max(input, dim, keepdim=False, *, out=None) -> (Tensor, LongTensor)
+    # elementwise: torch.max(input, other, *, out=None) -> Tensor
+
+    # the mapper function is remapping for both min and max situations
+    # this helper function makes the choices available clearer and provides an easier way
+    # to lookup the right function
+    def target_map(op, target):
+        if (op, target) in (("call_method", "max"), ("call_function", torch.max)):
+            return {
+                "full_reduce": max_full_reduce,
+                "dim_reduce": max_dim_reduce,
+                "elementwise": maximum,
+            }
+        elif (op, target) in (("call_method", "min"), ("call_function", torch.min)):
+            return {
+                "full_reduce": min_full_reduce,
+                "dim_reduce": min_dim_reduce,
+                "elementwise": minimum,
+            }
+
+    with node.graph.inserting_before(node):
+        new_targets = target_map(node.op, node.target)
+        max_kwargs = {}
+        max_kwargs["input"] = node.kwargs["input"]
+        if ("dim_or_other" not in node.kwargs) or (node.kwargs["dim_or_other"] is None):
+            nt = new_targets["full_reduce"]
+            max_node = node.graph.call_function(nt, kwargs=max_kwargs)
+        elif isinstance(node.kwargs["dim_or_other"], int):
+            nt = new_targets["dim_reduce"]
+            dim = node.kwargs["dim_or_other"]
+            max_kwargs["dim"] = dim
+            max_kwargs["keepdim"] = node.kwargs.get("keepdim", False)
+            max_node = node.graph.call_function(nt, kwargs=max_kwargs)
+        else:
+            other = node.kwargs["dim_or_other"]
+            assert isinstance(other, torch.fx.Node)
+            # Lowering path for when provided "other", where we do elem-wise max
+            nt = new_targets["elementwise"]
+            max_kwargs["other"] = other
+            max_node = node.graph.call_function(nt, kwargs=max_kwargs)
+        max_node.meta = node.meta.copy()
+        return max_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def max_full_reduce(*, input):
+    return torch.max(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def max_dim_reduce(*, input, dim=None, keepdim=False):
+    return torch.max(input=input, dim=dim, keepdim=keepdim)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.maximum))
+@register_acc_op_mapping(op_and_target=("call_method", "maximum"))
+@register_acc_op
+def maximum(*, input, other):
+    return torch.maximum(input=input, other=other)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def min_full_reduce(*, input):
+    return torch.min(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def min_dim_reduce(*, input, dim=None, keepdim=False):
+    return torch.min(input, dim=dim, keepdim=keepdim)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.minimum))
+@register_acc_op_mapping(op_and_target=("call_method", "minimum"))
+@register_acc_op
+def minimum(*, input, other):
+    return torch.minimum(input=input, other=other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.ne))
+@register_acc_op_mapping(op_and_target=("call_function", torch.ne))
+@register_acc_op_mapping(op_and_target=("call_method", "ne"))
+@register_acc_op
+def ne(*, input, other):
+    return operator.ne(input, other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.eq))
+@register_acc_op_mapping(op_and_target=("call_function", torch.eq))
+@register_acc_op_mapping(op_and_target=("call_method", "eq"))
+@register_acc_op
+def eq(*, input, other):
+    return operator.eq(input, other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.gt))
+@register_acc_op_mapping(op_and_target=("call_function", torch.gt))
+@register_acc_op_mapping(op_and_target=("call_method", "gt"))
+@register_acc_op
+def gt(*, input, other):
+    return operator.gt(input, other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.lt))
+@register_acc_op_mapping(op_and_target=("call_function", torch.lt))
+@register_acc_op_mapping(op_and_target=("call_method", "lt"))
+@register_acc_op
+def lt(*, input, other):
+    return operator.lt(input, other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.and_))
+@register_acc_op_mapping(op_and_target=("call_method", "bitwise_and"))
+@register_acc_op_mapping(op_and_target=("call_function", torch.bitwise_and))
+def bitwise_and(*, input, other):
+    return operator.and_(input, other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.logical_and))
+@register_acc_op_mapping(op_and_target=("call_method", "logical_and"))
+@register_acc_op
+def logical_and(*, input, other):
+    return torch.logical_and(input=input, other=other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.or_))
+@register_acc_op_mapping(op_and_target=("call_function", torch.logical_or))
+@register_acc_op_mapping(op_and_target=("call_method", "logical_or"))
+@register_acc_op
+def logical_or(*, input, other):
+    return torch.logical_or(input=input, other=other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.logical_not))
+@register_acc_op_mapping(op_and_target=("call_method", "logical_not"))
+@register_acc_op
+def logical_not(*, input):
+    return torch.logical_not(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", operator.xor))
+@register_acc_op_mapping(op_and_target=("call_function", torch.logical_xor))
+@register_acc_op_mapping(op_and_target=("call_method", "logical_xor"))
+@register_acc_op
+def logical_xor(*, input, other):
+    return torch.logical_xor(input=input, other=other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.isinf))
+@register_acc_op
+def isinf(*, input):
+    return torch.isinf(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def any(*, input, dim=None, keepdim=False):
+    if dim is not None:
+        return torch.any(input, dim, keepdim=keepdim)
+    else:
+        return torch.any(input)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.any),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "any"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+    ],
+)
+def any_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    with node.graph.inserting_before(node):
+        new_node = node.graph.call_function(any, kwargs=node.kwargs)
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise)
+@register_acc_op_mapping(op_and_target=("call_function", torch.fmod))
+@register_acc_op_mapping(op_and_target=("call_method", "fmod"))
+@register_acc_op
+def fmod(*, input, other):
+    return torch.fmod(input=input, other=other)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.sigmoid))
+@register_acc_op_mapping(op_and_target=("call_method", "sigmoid"))
+@register_acc_op
+def sigmoid(*, input):
+    return torch.sigmoid(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.sinh))
+@register_acc_op
+def sinh(*, input):
+    return torch.sinh(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.cosh))
+@register_acc_op
+def cosh(*, input):
+    return torch.cosh(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.tanh))
+@register_acc_op_mapping(op_and_target=("call_method", "tanh"))
+@register_acc_op
+def tanh(*, input):
+    return torch.tanh(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.asin))
+@register_acc_op
+def asin(*, input):
+    return torch.asin(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.acos))
+@register_acc_op
+def acos(*, input):
+    return torch.acos(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.atan))
+@register_acc_op
+def atan(*, input):
+    return torch.atan(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.exp))
+@register_acc_op
+def exp(*, input):
+    return torch.exp(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.log))
+@register_acc_op
+def log(*, input):
+    return torch.log(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.sqrt))
+@register_acc_op_mapping(op_and_target=("call_method", "sqrt"))
+@register_acc_op
+def sqrt(*, input):
+    return torch.sqrt(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.reciprocal))
+@register_acc_op
+def reciprocal(*, input):
+    return torch.reciprocal(input=input)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "rsqrt"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.rsqrt),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def rsqrt_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    input_node = node.kwargs["input"]
+    with node.graph.inserting_before(node):
+        new_kwargs = {
+            "input": input_node,
+        }
+        sqrt_node = node.graph.call_function(sqrt, kwargs=new_kwargs)
+        sqrt_node.meta["type"] = torch.Tensor
+        new_kwargs = {
+            "input": sqrt_node,
+        }
+        rec_node = node.graph.call_function(reciprocal, kwargs=new_kwargs)
+        rec_node.meta["type"] = torch.Tensor
+        output_node = rec_node
+        output_node.meta = node.meta.copy()
+        return output_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.abs))
+@register_acc_op
+def abs(*, input):
+    return torch.abs(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", operator.neg))
+@register_acc_op_mapping(op_and_target=("call_function", torch.neg))
+@register_acc_op
+def neg(*, input):
+    return torch.neg(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.floor))
+@register_acc_op
+def floor(*, input):
+    return torch.floor(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.ceil))
+@register_acc_op
+def ceil(*, input):
+    return torch.ceil(input=input)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.pad))
+@register_acc_op
+def pad(*, input, pad: List[int], mode: str, value: float):
+    return torch.nn.functional.pad(input=input, pad=pad, mode=mode, value=value)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.conv1d))
+@register_acc_op
+def conv1d(*, input, weight, bias, stride, padding, dilation, groups):
+    return nn.functional.conv1d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.conv2d))
+@register_acc_op
+def conv2d(*, input, weight, bias, stride, padding, dilation, groups):
+    return nn.functional.conv2d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+    )
+
+
+@register_acc_op_properties(AccOpProperty.quantized)
+@register_acc_op
+def quantized_conv2d(
+    *,
+    input,
+    weight,
+    bias,
+    stride,
+    padding,
+    dilation,
+    groups,
+    padding_mode,
+    acc_out_ty=None,
+):
+    qparams = acc_out_ty.qparams
+    return torch.nn.quantized.functional.conv2d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+        padding_mode=padding_mode,
+        scale=qparams["scale"],
+        zero_point=qparams["zero_point"],
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.conv3d))
+@register_acc_op
+def conv3d(*, input, weight, bias, stride, padding, dilation, groups):
+    return nn.functional.conv3d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.nn.functional.conv_transpose2d)
+)
+@register_acc_op
+def conv_transpose2d(
+    *,
+    input,
+    weight,
+    bias,
+    stride,
+    padding,
+    output_padding,
+    groups,
+    dilation,
+):
+    return nn.functional.conv_transpose2d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.nn.functional.conv_transpose3d)
+)
+@register_acc_op
+def conv_transpose3d(
+    *,
+    input,
+    weight,
+    bias,
+    stride,
+    padding,
+    output_padding,
+    groups,
+    dilation,
+):
+    return nn.functional.conv_transpose3d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.batch_norm))
+@register_acc_op
+def batch_norm(
+    *,
+    input,
+    running_mean,
+    running_var,
+    weight,
+    bias,
+    training,
+    momentum,
+    eps,
+):
+    return nn.functional.batch_norm(
+        input=input,
+        running_mean=running_mean,
+        running_var=running_var,
+        weight=weight,
+        bias=bias,
+        training=training,
+        momentum=momentum,
+        eps=eps,
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.layer_norm))
+@register_acc_op
+def layer_norm(*, input, normalized_shape, weight, bias, eps):
+    return nn.functional.layer_norm(
+        input=input,
+        normalized_shape=normalized_shape,
+        weight=weight,
+        bias=bias,
+        eps=eps,
+    )
+
+
+def argmin_max_mapper_impl(node: torch.fx.Node, largest: bool) -> torch.fx.Node:
+    """
+    Map torch.argmin or torch.argmax to acc_ops.flatten (depend on dim) + acc_ops.topk
+    + acc_ops.getitem + acc_ops.squeeze (depends on keepdim).
+    """
+    input_node = node.kwargs["input"]
+    dim = node.kwargs["dim"]
+    keepdim = node.kwargs["keepdim"]
+
+    if dim is None and keepdim:
+        raise RuntimeError(
+            "We currently don't support argmin/argmax with dim=None and keepdim=True"
+        )
+
+    with node.graph.inserting_before(node):
+        if dim is None:
+            flatten_kwargs = {
+                "input": node.kwargs["input"],
+                "start_dim": 0,
+                "end_dim": -1,
+            }
+            flatten_node = node.graph.call_function(flatten, kwargs=flatten_kwargs)
+            flatten_node.meta["type"] = torch.Tensor
+            input_node = flatten_node
+            dim = -1
+
+        topk_kwargs = {
+            "input": input_node,
+            "k": 1,
+            "dim": dim,
+            "largest": largest,
+            "sorted": False,
+        }
+        topk_node = node.graph.call_function(topk, kwargs=topk_kwargs)
+        # It's actually more like NamedTuple but tuple here should be fine.
+        topk_node.meta["type"] = tuple
+
+        getitem_kwargs = {"input": topk_node, "idx": 1}
+        getitem_node = node.graph.call_function(getitem, kwargs=getitem_kwargs)
+        getitem_node.meta["type"] = torch.Tensor
+        output_node = getitem_node
+
+        if not keepdim:
+            squeeze_kwargs = {"input": getitem_node, "dim": dim}
+            output_node = node.graph.call_function(squeeze, kwargs=squeeze_kwargs)
+
+        output_node.meta = node.meta.copy()
+        return output_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.argmin),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("keepdim", "keepdim"),
+    ],
+)
+def torch_argmin_mapper(node: torch.fx.Node, _: torch.nn.Module) -> torch.fx.Node:
+    """
+    Map torch.argmin to acc_ops.flatten (depend on dim) + acc_ops.topk + acc_ops.getitem
+    + acc_ops.squeeze (depends on keepdim).
+    """
+    return argmin_max_mapper_impl(node, largest=False)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.linalg.norm))
+@register_acc_op
+def linalg_norm(*, input, ord, dim, keepdim):
+    return torch.linalg.norm(input=input, ord=ord, dim=dim, keepdim=keepdim)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.functional.norm),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("p", "p"),
+        ("dim", "dim"),
+        ("keepdim", "keepdim"),
+    ],
+)
+def norm_mapper(node: torch.fx.Node, _: torch.nn.Module) -> torch.fx.Node:
+
+    input_node = node.kwargs["input"]
+    p = node.kwargs["p"]
+    dim = node.kwargs["dim"]
+    keepdim = node.kwargs["keepdim"]
+    output_node = None
+    with node.graph.inserting_before(node):
+        if dim is None and p == 1:
+            # linalg_norm takes the max along the sum along a dim
+            # rather than the entire sum for p = 1
+            abs_node = node.graph.call_function(abs, kwargs={"input": input_node})
+            output_node = node.graph.call_function(
+                sum,
+                kwargs={"input": abs_node},
+            )
+        elif dim is None:
+            raise RuntimeError("dim=None has not been implemented for p != 1")
+        else:
+            output_node = node.graph.call_function(
+                linalg_norm,
+                kwargs={"input": input_node, "ord": p, "dim": dim, "keepdim": keepdim},
+            )
+
+    return output_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "split"),
+    arg_replacement_tuples=[
+        ("tensor", "input"),
+        ("split_size_or_sections", "split_size_or_sections"),
+        ("dim", "dim"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "split_with_sizes"),
+    arg_replacement_tuples=[
+        ("tensor", "input"),
+        ("split_sizes", "split_size_or_sections"),
+        ("dim", "dim"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.split),
+    arg_replacement_tuples=[
+        ("tensor", "input"),
+        ("split_size_or_sections", "split_size_or_sections"),
+        ("dim", "dim"),
+    ],
+)
+def torch_split_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
+    """
+    If split_size_or_sections is sections, map the node to slice_tensors
+    + tuple_construct. Otherwise, if split_size_or_sections is split_size,
+    map the node to acc_ops.split.
+    """
+    split_size_or_sections = node.kwargs["split_size_or_sections"]
+    with node.graph.inserting_before(node):
+        if isinstance(split_size_or_sections, int):
+            new_kwargs = {
+                "input": node.kwargs["input"],
+                "split_size": split_size_or_sections,
+                "dim": node.kwargs["dim"],
+            }
+            new_node = node.graph.call_function(split, kwargs=new_kwargs)
+            new_node.meta = node.meta.copy()
+            return new_node
+
+        assert isinstance(split_size_or_sections, Sequence)
+        start = 0
+        slice_nodes = []
+        for i in split_size_or_sections:
+            assert isinstance(i, int)
+            new_kwargs = {
+                "input": node.kwargs["input"],
+                "dim": node.kwargs["dim"],
+                "start": start,
+                "stop": start + i,
+                "step": 1,
+            }
+            new_node = node.graph.call_function(slice_tensor, kwargs=new_kwargs)
+            new_node.meta["type"] = torch.Tensor
+            slice_nodes.append(new_node)
+            start += i
+
+        new_node = node.graph.call_function(
+            tuple_construct, kwargs={"tensors": tuple(slice_nodes)}
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def split(*, input, split_size, dim):
+    return torch.split(input, split_size, dim)
+
+
+@register_acc_op
+def tuple_construct(*, tensors):
+    return tuple(tensors)
+
+
+@register_acc_op_properties(AccOpProperty.quantized)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.ops.quantized.batch_norm2d),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("weight", "weight"),
+        ("bias", "bias"),
+        ("running_mean", "running_mean"),
+        ("running_var", "running_var"),
+        ("eps", "eps"),
+        ("scale", "scale"),
+        ("zero_point", "zero_point"),
+    ],
+    kwargs_to_move_to_acc_out_ty=[
+        ("scale", "scale", move_to_qparams),
+        ("zero_point", "zero_point", move_to_qparams),
+    ],
+)
+@register_acc_op
+def quantized_batch_norm2d(
+    *,
+    input,
+    running_mean,
+    running_var,
+    weight,
+    bias,
+    eps,
+    acc_out_ty=None,
+):
+    qparams = acc_out_ty.qparams
+    return torch.ops.quantized.batch_norm2d(
+        input,
+        weight,
+        bias,
+        running_mean,
+        running_var,
+        eps,
+        qparams["scale"],
+        qparams["zero_point"],
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", nn.functional.embedding_bag))
+@register_acc_op
+def embedding_bag(
+    *,
+    input,
+    weight,
+    offsets,
+    max_norm,
+    norm_type,
+    scale_grad_by_freq,
+    mode,
+    sparse,
+    per_sample_weights,
+    include_last_offset,
+    padding_idx,
+):
+    return nn.functional.embedding_bag(
+        input=input,
+        weight=weight,
+        offsets=offsets,
+        max_norm=max_norm,
+        norm_type=norm_type,
+        scale_grad_by_freq=scale_grad_by_freq,
+        mode=mode,
+        sparse=sparse,
+        per_sample_weights=per_sample_weights,
+        include_last_offset=include_last_offset,
+        padding_idx=padding_idx,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=(
+        "call_function",
+        torch.ops.quantized.embedding_bag_byte_rowwise_offsets,
+    )
+)
+@register_acc_op
+def embedding_bag_byte_rowwise_offsets(
+    *,
+    weight,
+    indices,
+    offsets,
+    scale_grad_by_freq,
+    mode,
+    pruned_weights,
+    per_sample_weights,
+    compressed_indices_mapping,
+    include_last_offset,
+):
+    return torch.ops.quantized.embedding_bag_byte_rowwise_offsets(
+        weight=weight,
+        indices=indices,
+        offsets=offsets,
+        scale_grad_by_freq=scale_grad_by_freq,
+        mode=mode,
+        pruned_weights=pruned_weights,
+        per_sample_weights=per_sample_weights,
+        compressed_indices_mapping=compressed_indices_mapping,
+        include_last_offset=include_last_offset,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=(
+        "call_function",
+        torch.ops.quantized.embedding_bag_4bit_rowwise_offsets,
+    )
+)
+@register_acc_op
+def embedding_bag_4bit_rowwise_offsets(
+    *,
+    weight,
+    indices,
+    offsets,
+    scale_grad_by_freq,
+    mode,
+    pruned_weights,
+    per_sample_weights,
+    compressed_indices_mapping,
+    include_last_offset,
+):
+    return torch.ops.quantized.embedding_bag_4bit_rowwise_offsets(
+        weight=weight,
+        indices=indices,
+        offsets=offsets,
+        scale_grad_by_freq=scale_grad_by_freq,
+        mode=mode,
+        pruned_weights=pruned_weights,
+        per_sample_weights=per_sample_weights,
+        compressed_indices_mapping=compressed_indices_mapping,
+        include_last_offset=include_last_offset,
+    )
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.sin))
+@register_acc_op
+def sin(*, input):
+    return torch.sin(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.cos))
+@register_acc_op
+def cos(*, input):
+    return torch.cos(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.tan))
+@register_acc_op
+def tan(*, input):
+    return torch.tan(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.topk))
+@register_acc_op
+def topk(*, input, k, dim, largest, sorted):
+    return torch.topk(input=input, k=k, dim=dim, largest=largest, sorted=sorted)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", operator.getitem))
+@register_acc_op
+def getitem(*, input, idx):
+    return input[idx]
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.nan_to_num))
+@register_acc_op_mapping(op_and_target=("call_method", "nan_to_num"))
+@register_acc_op
+def nan_to_num(*, input, nan=0.0, posinf=None, neginf=None):
+    return torch.nan_to_num(input, nan=nan, posinf=posinf, neginf=neginf)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "expand"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("*", "sizes"),
+    ],
+)
+@register_acc_op
+def expand(*, input, sizes):
+    return input.expand(*sizes)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.masked_fill),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mask", "mask"),
+        ("value", "value"),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "masked_fill"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("mask", "mask"),
+        ("value", "value"),
+    ],
+)
+@register_acc_op
+def masked_fill(*, input, mask, value):
+    return input.masked_fill(mask, value)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.where))
+@register_acc_op
+def where(*, condition, x, y):
+    return torch.where(condition, x, y)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
+def slice_tensor(*, input, dim, start, stop, step):
+    slc = slice(start, stop, step)
+    if dim >= 0:
+        slices: List[slice] = [slice(None, None, None) for _ in range(dim)]
+        slices.append(slc)
+    else:
+        slices = [Ellipsis, slc]  # type: ignore[list-item]
+        slices.extend([slice(None, None, None) for _ in range(-dim - 1)])
+
+    return input[tuple(slices)]
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.narrow),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("start", "start"),
+        ("length", "length"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "narrow"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("start", "start"),
+        ("length", "length"),
+    ],
+)
+def custom_narrow_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
+    assert isinstance(node.kwargs["start"], int) and isinstance(
+        node.kwargs["length"], int
+    )
+    kwargs = {
+        "input": node.kwargs["input"],
+        "dim": node.kwargs["dim"],
+        "start": node.kwargs["start"],
+        "stop": node.kwargs["start"] + node.kwargs["length"],
+        "step": 1,
+    }
+    with node.graph.inserting_before(node):
+        new_node = node.graph.call_function(slice_tensor, kwargs=kwargs)
+    new_node.meta = node.meta.copy()
+    return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.reshape),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("shape", "shape"),
+    ],
+    kwargs_to_move_to_acc_out_ty=[("shape", "shape")],
+)
+@register_acc_op
+def reshape(*, input, acc_out_ty=None):
+    assert acc_out_ty is not None
+    return input.reshape(acc_out_ty.shape)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "reshape"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("*", "shape"),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "view"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("*", "shape"),
+    ],
+)
+def custom_tensor_reshape_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    For Tensor.reshape and Tensor.view nodes, args could be (input, 1, 2, 3) or (input,
+    (1, 2, 3)).  Here we do some special handling with the `shape` arg in order to map
+    it to acc_ops.reshape. It also handles the case when `shape` is a list instead of
+    tuple.
+    """
+    input_node = node.kwargs["input"]
+    shape = node.kwargs["shape"]
+
+    assert isinstance(shape, Sequence)
+    if isinstance(shape[0], (tuple, list)):  # type: ignore[index]
+        shape = shape[0]  # type: ignore[index]
+
+    with node.graph.inserting_before(node):
+        new_node = node.graph.call_function(
+            reshape,
+            kwargs={
+                "input": input_node,
+                "acc_out_ty": acc_utils.build_raw_tensor_meta(shape=shape),
+            },
+        )
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "half"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def custom_half_mapper(node: torch.fx.Node, _: nn.Module):
+    with node.graph.inserting_before(node):
+        new_kwargs = {
+            "input": node.kwargs["input"],
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=torch.float16),
+        }
+        new_node = node.graph.call_function(to_dtype, kwargs=new_kwargs)
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "int"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def custom_int_mapper(node: torch.fx.Node, _: nn.Module):
+    with node.graph.inserting_before(node):
+        new_kwargs = {
+            "input": node.kwargs["input"],
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=torch.int),
+        }
+        new_node = node.graph.call_function(to_dtype, kwargs=new_kwargs)
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "float"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def custom_float_mapper(node: torch.fx.Node, _: nn.Module):
+    with node.graph.inserting_before(node):
+        new_kwargs = {
+            "input": node.kwargs["input"],
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=torch.float),
+        }
+        new_node = node.graph.call_function(to_dtype, kwargs=new_kwargs)
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op
+def to_dtype(input, acc_out_ty=None, device=None):
+    assert acc_out_ty is not None
+    return input.to(dtype=acc_out_ty.dtype, device=device)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "to"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dtype", "dtype"),
+        ("device", "device", this_arg_is_optional),
+    ],
+)
+def custom_tensor_to_mapper(node: torch.fx.Node, _: nn.Module):
+    dest = node.kwargs["dtype"]
+    mem_format = node.kwargs.get("memory_format")
+    dest_other = node.kwargs.get("device")
+    assert dest is not None
+    assert mem_format is None or mem_format == torch.preserve_format
+
+    dest_dtype = dest_device = None
+    if isinstance(dest, torch.fx.node.Node):
+        meta_type = dest.meta["type"]
+        # consider the device is gpu only, meta info is limited to give clear device type
+        if dest.meta["type"] == torch.device:
+            dest_device = dest
+        elif dest.meta["type"] == torch.dtype:
+            dest_dtype = dest
+        elif dest.meta["type"] == torch.Tensor:
+            input_obj = node.kwargs["input"]
+            other_obj = dest
+            with node.graph.inserting_before(node):
+                dtype_node = node.graph.call_function(
+                    dtype, kwargs={"input": other_obj}
+                )
+                dtype_node.meta["type"] = torch.dtype
+                device_node = node.graph.call_function(
+                    device, kwargs={"input": other_obj}
+                )
+                device_node.meta["type"] = torch.device
+                new_kwargs = {
+                    "input": input_obj,
+                    "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=dtype_node),
+                    "device": device_node,
+                }
+                new_node = node.graph.call_function(to_dtype, kwargs=new_kwargs)
+                new_node.meta = node.meta
+                return new_node
+        else:
+            raise RuntimeError(f"We currently do not support to({meta_type})")
+    elif isinstance(dest, torch.device):
+        # only device is set, dtype=None
+        if dest_other is None:
+            dest_device = dest
+        # device and dtype are both set
+        else:
+            dest_dtype = dest_other
+            dest_device = dest
+    # only dtype is set
+    else:
+        dest_dtype = dest
+
+    new_kwargs = {
+        "input": node.kwargs["input"],
+        "acc_out_ty": acc_utils.build_raw_tensor_meta(dtype=dest_dtype),
+        "device": dest_device,
+    }
+
+    with node.graph.inserting_before(node):
+        new_node = node.graph.create_node(
+            "call_function", to_dtype, kwargs=new_kwargs, name=node.name
+        )
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.add),
+    # Note that we may have aliases for inputs here due to issues with deterministically
+    # knowing the correct target that will be resolved by pytorch.
+    arg_replacement_tuples=[
+        (("input", "a"), "input"),
+        (("other", "b"), "other"),
+        ("alpha", "alpha", this_arg_is_optional),
+    ],
+)
+def custom_torch_add_mapper(node: torch.fx.Node, mod: nn.Module) -> torch.fx.Node:
+    """
+    Add custom mapping for torch.add because it has an `alpha` parameter which scales
+    the `other` input, and we want to make that mul a separate node.
+    """
+    with node.graph.inserting_before(node):
+        # If alpha is in kwargs check if we need to add a mul, and use correct kwargs.
+        if "alpha" in node.kwargs:
+            # Add mul node only if it has a numerical impact, i.e. alpha != 1.0.
+            if node.kwargs["alpha"] != 1.0:
+                other_node = node.graph.create_node(
+                    "call_function",
+                    mul,
+                    kwargs={
+                        "input": node.kwargs["other"],
+                        "other": node.kwargs["alpha"],
+                    },
+                    name=node.name + "_mul_alpha",
+                )
+                other_node.meta = node.meta
+            else:
+                other_node = node.kwargs["other"]
+            add_kwargs = {"input": node.kwargs["input"], "other": other_node}
+        else:
+            add_kwargs = node.kwargs
+
+        new_node = node.graph.create_node(
+            "call_function", add, kwargs=add_kwargs, name=node.name
+        )
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_module", nn.quantized.Linear),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def packed_quantized_linear_mapper(
+    node: torch.fx.Node, mod: nn.Module
+) -> torch.fx.Node:
+    """
+    Mapping from quantized_linear module to acc_op.linear. We unpack weight and bias
+    in this mapper and pass them directly to linear node.
+    """
+    assert isinstance(node.target, str)
+    linear_module = dict(mod.named_modules())[node.target]
+    prefix = node.target.replace(".", "_")
+    weight_name = f"{prefix}_weight"
+    bias_name = f"{prefix}_bias"
+
+    # Store weight and bias in the main module
+    mod.register_buffer(weight_name, linear_module.weight())
+    if linear_module.bias() is not None:
+        mod.register_buffer(bias_name, linear_module.bias())
+
+    with node.graph.inserting_before(node):
+        # Insert get_attr nodes for weight and bias
+        get_weight = node.graph.get_attr(weight_name)
+        get_weight.meta["tensor_meta"] = _extract_tensor_metadata(
+            linear_module.weight()
+        )
+
+        get_bias = None
+        if linear_module.bias() is not None:
+            get_bias = node.graph.get_attr(bias_name)
+            get_bias.meta["tensor_meta"] = _extract_tensor_metadata(
+                linear_module.bias()
+            )
+
+        qparams = {"scale": linear_module.scale, "zero_point": linear_module.zero_point}
+        # Create kwargs for acc_op.quantized_linear
+        kwargs = {
+            "input": node.kwargs["input"],
+            "weight": get_weight,
+            "bias": get_bias,
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(qparams=qparams),
+        }
+
+        new_node = node.graph.call_function(quantized_linear, kwargs=kwargs)
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_module", nn.quantized.Conv2d),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def packed_quantized_conv2d_mapper(
+    node: torch.fx.Node, mod: nn.Module
+) -> torch.fx.Node:
+    """
+    Mapping from quantzed Conv2d module to acc_op.conv. We unpack all the parameters
+    in this mapper and pass them directly to conv2d node.
+    """
+    assert isinstance(node.target, str)
+    conv_module = dict(mod.named_modules())[node.target]
+    prefix = node.target.replace(".", "_")
+    weight_name = f"{prefix}_weight"
+    bias_name = f"{prefix}_bias"
+
+    # Store weight and bias in the main module
+    mod.register_buffer(weight_name, conv_module.weight())
+    if conv_module.bias() is not None:
+        mod.register_buffer(bias_name, conv_module.bias())
+
+    with node.graph.inserting_before(node):
+        # Insert get_attr nodes for weight and bias
+        get_weight = node.graph.get_attr(weight_name)
+        get_weight.meta["tensor_meta"] = _extract_tensor_metadata(conv_module.weight())
+
+        get_bias = None
+        if conv_module.bias() is not None:
+            get_bias = node.graph.get_attr(bias_name)
+            get_bias.meta["tensor_meta"] = _extract_tensor_metadata(conv_module.bias())
+
+        qparams = {"scale": conv_module.scale, "zero_point": conv_module.zero_point}
+
+        # Create kwargs for acc_op.conv
+        kwargs = {
+            "input": node.kwargs["input"],
+            "weight": get_weight,
+            "bias": get_bias,
+            "stride": conv_module.stride,
+            "padding": conv_module.padding,
+            "dilation": conv_module.dilation,
+            "groups": conv_module.groups,
+            "padding_mode": conv_module.padding_mode,
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(qparams=qparams),
+        }
+
+        new_node = node.graph.call_function(quantized_conv2d, kwargs=kwargs)
+        new_node.meta = node.meta
+        return new_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.ops.quantized.add_relu),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+        ("scale", "scale"),
+        ("zero_point", "zero_point"),
+    ],
+)
+def add_relu_unfuse_mapper(
+    node: torch.fx.Node, mod: torch.fx.GraphModule
+) -> torch.fx.Node:
+    with node.graph.inserting_before(node):
+        qparams = {
+            "scale": node.kwargs["scale"],
+            "zero_point": node.kwargs["zero_point"],
+        }
+        add_kwargs = {
+            "input": node.kwargs["input"],
+            "other": node.kwargs["other"],
+            "acc_out_ty": acc_utils.build_raw_tensor_meta(qparams=qparams),
+        }
+        add_node = node.graph.call_function(quantized_add, kwargs=add_kwargs)
+        add_node.meta = node.meta.copy()
+
+        relu_node = node.graph.call_function(
+            relu, kwargs={"input": add_node, "inplace": False}
+        )
+        relu_node.meta = node.meta
+        return relu_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_module", nn.intrinsic.quantized.ConvReLU2d),
+    arg_replacement_tuples=[
+        ("input", "input"),
+    ],
+)
+def packed_quantized_convrelu2d_mapper(
+    node: torch.fx.Node, mod: nn.Module
+) -> torch.fx.Node:
+    """
+    Mapping from quantized ConvReLU2d module to acc_op.relu. We use packed_quantized_conv2d_mapper to unpack all the parameters
+    in this mapper and pass the returned conv2d node directly to relu node.
+    """
+
+    with node.graph.inserting_before(node):
+        # conv2d op
+        conv2d_node = packed_quantized_conv2d_mapper(node, mod)
+
+        # relu op
+        relu_node = node.graph.call_function(
+            relu, kwargs={"input": conv2d_node, "inplace": False}
+        )
+        relu_node.meta = node.meta
+        return relu_node
+
+
+@register_acc_op_properties(AccOpProperty.pointwise, AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.nn.functional.gelu))
+@register_acc_op_mapping(op_and_target=("call_method", "gelu"))
+@register_acc_op
+def gelu(*, input):
+    return torch.nn.functional.gelu(input=input)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.cumsum))
+@register_acc_op_mapping(op_and_target=("call_method", "cumsum"))
+@register_acc_op
+def cumsum(*, input, dim, dtype=None):
+    return torch.cumsum(input=input, dim=dim, dtype=dtype)
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op_mapping(op_and_target=("call_function", torch.chunk))
+@register_acc_op_mapping(op_and_target=("call_method", "chunk"))
+@register_acc_op
+def chunk(*, input, chunks, dim=0):
+    return torch.chunk(input=input, chunks=chunks, dim=dim)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.gather),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("index", "index"),
+        ("sparse_grad", "sparse_grad", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def gather(*, input, dim, index, sparse_grad=False):
+    return torch.gather(input=input, dim=dim, index=index, sparse_grad=sparse_grad)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.index_select),
+)
+@register_acc_op
+def index_select(*, input, dim, index):
+    return torch.index_select(input, dim, index)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "expand_as"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("other", "other"),
+    ],
+)
+def expand_as_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Maps expand_as(other) to expand(other.size())
+    """
+    with node.graph.inserting_before(node):
+        size_node = node.graph.call_function(
+            size, kwargs={"input": node.kwargs["other"]}
+        )
+        size_node.meta["type"] = torch.Size
+
+        expand_node = node.graph.call_function(
+            expand, kwargs={"input": node.kwargs["input"], "sizes": size_node}
+        )
+        expand_node.meta = node.meta.copy()
+        return expand_node
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.nn.functional.grid_sample),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("grid", "grid"),
+        ("mode", "mode", this_arg_is_optional),
+        ("padding_mode", "padding_mode", this_arg_is_optional),
+        ("align_corners", "align_corners", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def grid_sample(
+    *,
+    input,
+    grid,
+    mode="bilinear",
+    padding_mode="zeros",
+    align_corners=None,
+):
+    return torch.nn.functional.grid_sample(
+        input=input,
+        grid=grid,
+        mode=mode,
+        padding_mode=padding_mode,
+        align_corners=align_corners,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.nn.functional.interpolate),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size", this_arg_is_optional),
+        ("scale_factor", "scale_factor", this_arg_is_optional),
+        ("mode", "mode", this_arg_is_optional),
+        ("align_corners", "align_corners", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def interpolate(
+    *,
+    input,
+    size=None,
+    scale_factor=None,
+    mode="nearest",
+    align_corners=None,
+):
+    return torch.nn.functional.interpolate(
+        input=input,
+        size=size,
+        scale_factor=scale_factor,
+        mode=mode,
+        align_corners=align_corners,
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.tensor_split),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("tensor_indices_or_sections", "sections", "indices"), "indices_or_sections"),
+        ("dim", "dim", this_arg_is_optional),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "tensor_split"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        (("tensor_indices_or_sections", "sections", "indices"), "indices_or_sections"),
+        ("dim", "dim", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def tensor_split(*, input, indices_or_sections, dim=0):
+    # Need to de-coalesce the indices_or_sections because tensor_split accepts
+    # one of three kwarg signatures:
+    #  * (Tensor input, Tensor tensor_indices_or_sections, int dim)
+    #  * (Tensor input, int sections, int dim)
+    #  * (Tensor input, tuple of ints indices, int dim)
+    if isinstance(indices_or_sections, torch.Tensor):
+        indices_or_sections = indices_or_sections.tolist()
+    if isinstance(indices_or_sections, int):
+        return torch.tensor_split(input, sections=indices_or_sections, dim=dim)
+    elif isinstance(indices_or_sections, Iterable):
+        return torch.tensor_split(input, indices=tuple(indices_or_sections), dim=dim)
+    else:
+        raise RuntimeError(
+            f"Expected int, Iterable or Tensor for "
+            f"indices_or_sections arg, got: {type(indices_or_sections)}"
+        )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_method", "new_ones"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("dtype", "dtype", this_arg_is_optional),
+        ("device", "device", this_arg_is_optional),
+        ("requires_grad", "requires_grad", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def new_ones(*, input, size, dtype=None, device=None, requires_grad=False):
+    assert requires_grad is False, f"requires_grad != False, it is {requires_grad}"
+    return input.new_ones(size, dtype=dtype, device=device)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_method", "new_empty"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("dtype", "dtype", this_arg_is_optional),
+        ("device", "device", this_arg_is_optional),
+        ("requires_grad", "requires_grad", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def new_empty(*, input, size, dtype=None, device=None, requires_grad=False):
+    assert requires_grad is False, f"requires_grad != False, it is {requires_grad}"
+    return input.new_empty(size, dtype=dtype, device=device)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.einsum),
+    arg_replacement_tuples=[
+        ("equation", "equation"),
+        ("*", "operands"),
+    ],
+)
+@register_acc_op
+def einsum(*, equation, operands):
+    return torch.einsum(equation, *operands)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_function", torch.as_strided),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("stride", "stride"),
+        ("storage_offset", "storage_offset", this_arg_is_optional),
+    ],
+)
+@register_acc_op_mapping(
+    op_and_target=("call_method", "as_strided"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("stride", "stride"),
+        ("storage_offset", "storage_offset", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def as_strided(*, input, size, stride, storage_offset=0):
+    return torch.as_strided(
+        input=input, size=size, stride=stride, storage_offset=storage_offset
+    )
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.var))
+@register_acc_op_mapping(
+    op_and_target=("call_method", "var"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("unbiased", "unbiased"),
+        ("keepdim", "keepdim"),
+    ],
+)
+@register_acc_op
+def var(*, input, dim, unbiased, keepdim=False):
+    return torch.var(input=input, dim=dim, unbiased=unbiased, keepdim=keepdim)
+
+
+@register_acc_op
+def xl_weight(weight_id: str, metadata: TensorMetadata, proxy_shape, dtype):
+    """
+    This op stores metadata and weight_id and otherwise returns a zeros tensor
+    with shape `proxy_shape` and dtype `dtype`.
+
+    Note: when Nodes with this op are run through ShapeProp, its metadata will
+    be the same as computed and set as of that of `proxy`, however when running
+    acc_shape_inference, it will return `metadata`.
+
+    Args:
+        weight_id: string identifier for the XL weight
+        metadata: metadata of the XL weight
+        proxy_shape: shape of substitute tensor
+        dtype: dtype of substitute tensor
+    """
+    return torch.zeros(proxy_shape, dtype=dtype)
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.nn.functional.log_softmax),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim"),
+        ("dtype", "dtype"),
+    ],
+)
+def log_softmax_mapper(node: torch.fx.Node, _: torch.nn.Module) -> torch.fx.Node:
+    with node.graph.inserting_after(node):
+
+        softmax_kwargs = {
+            "input": node.kwargs["input"],
+            "dim": node.kwargs["dim"],
+            "dtype": node.kwargs["dtype"],
+        }
+        softmax_node = node.graph.call_function(softmax, kwargs=softmax_kwargs)
+        softmax_node.meta = node.meta.copy()
+
+    with softmax_node.graph.inserting_after(softmax_node):
+        log_kwargs = {"input": softmax_node}
+        log_node = node.graph.call_function(log, kwargs=log_kwargs)
+        log_node.meta = node.meta.copy()
+
+        return log_node
+
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.baddbmm),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("batch1", "batch1"),
+        ("batch2", "batch2"),
+        ("beta", "beta", this_arg_is_optional),
+        ("alpha", "alpha", this_arg_is_optional),
+    ],
+)
+def baddbmm_mapper(node: torch.fx.Node, _: nn.Module) -> torch.fx.Node:
+    """
+    Mapping from torch.baddbmm to acc_ops.mm -> acc_ops.add, if alpha or beta is not 1
+    then we also insert acc_ops.mul to the right place.
+    """
+    with node.graph.inserting_before(node):
+        mm_kwargs = {"input": node.kwargs["batch1"], "other": node.kwargs["batch2"]}
+        mm_node = node.graph.create_node(
+            "call_function", matmul, kwargs=mm_kwargs, name=f"{node.name}_matmul"
+        )
+        mm_node.meta = node.meta.copy()
+
+        if node.kwargs["alpha"] != 1:
+            mul_kwargs = {"input": mm_node, "other": node.kwargs["alpha"]}
+            mm_node = node.graph.create_node(
+                "call_function", mul, kwargs=mul_kwargs, name=f"{mm_node.name}_mul"
+            )
+        mm_node.meta = node.meta.copy()
+
+        input_node = node.kwargs["input"]
+        if node.kwargs["beta"] != 1:
+            mul_kwargs = {"input": input_node, "other": node.kwargs["beta"]}
+            new_input_node = node.graph.create_node(
+                "call_function", mul, kwargs=mul_kwargs, name=f"{node.name}_input_mul"
+            )
+            assert isinstance(input_node, torch.fx.Node)
+            new_input_node.meta = input_node.meta.copy()
+            input_node = new_input_node
+
+        add_kwargs = {"input": input_node, "other": mm_node}
+        add_node = node.graph.create_node(
+            "call_function", add, kwargs=add_kwargs, name=f"{node.name}_add"
+        )
+        add_node.meta = node.meta.copy()
+        return add_node
+
+
+###############################################################################
+
+# Set ops as side-effectul, this prevents them from being optimized away or
+# being folded into constants.
+torch.fx.node._side_effectful_functions.add(xl_weight)

--- a/olla/acc_tracer/acc_shape_prop.py
+++ b/olla/acc_tracer/acc_shape_prop.py
@@ -1,0 +1,110 @@
+import os
+import sys
+from typing import Any
+
+import torch.fx
+
+# TODO: import properly from third-party library
+# import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_ops
+import olla.acc_tracer.acc_ops as acc_ops
+
+from torch.fx.passes import shape_prop
+
+
+class SuppressStderrPrints:
+    def __enter__(self):
+        self._original_stderr = sys.stderr
+        sys.stderr = open(os.devnull, "w")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stderr.close()
+        sys.stderr = self._original_stderr
+
+
+class AccShapeProp(shape_prop.ShapeProp):
+    """
+    Similar to standard shape prop, but if any node that is run with standard shape prop
+    fails then it tries to upconvert any fp16 inputs to fp32, rerun shape prop, and then
+    downconvert fp32 results back to fp16.
+
+    Note that we currently mostly only look for/support up/down conversion for nodes
+    with tensor outputs, but this is likely fine for most cases. Additionally the base
+    shape_prop works for many ops with fp16, such as tensor.cat, tensor slice, tensor.to
+    dtype conversion, etc.
+
+    """
+
+    def _run_node(self, n: torch.fx.Node) -> Any:
+        # Run embedding bag ops with XL weights in a customized way, see
+        # docstring for self.run_embedding_bag for more details
+        if (
+            n.target
+            in {
+                acc_ops.embedding_bag,
+                acc_ops.embedding_bag_4bit_rowwise_offsets,
+                acc_ops.embedding_bag_byte_rowwise_offsets,
+            }
+            and n.kwargs["weight"].target == acc_ops.xl_weight
+        ):
+            return self.run_embedding_bag(n)
+        return super().run_node(n)
+
+    def run_node(self, n: torch.fx.Node) -> Any:
+        # First try running shape_prop with the original inputs.
+        with SuppressStderrPrints():
+            try:
+                return self._run_node(n)
+            except Exception:
+                pass
+
+        # Base shape_prop failed, so temporarily upconvert the node's fp16 inputs in env
+        # and retry. For now just support upconverting Tensor outputs.
+        orig_dtype_env = []
+        for in_node in n.all_input_nodes:
+            in_ten = self.env[in_node]
+            if isinstance(in_ten, torch.Tensor) and in_ten.dtype == torch.float16:
+                orig_dtype_env.append((in_node, in_ten))
+                self.env[in_node] = in_ten.clone().to(dtype=torch.float)
+
+        # Now try running again with upconverted fp32 input tensor in env.
+        result = self._run_node(n)
+
+        # Now that we succeeded, assume it's thanks to upconverting. Therefore we
+        # downconvert fp32 tensor results to fp16.
+        if isinstance(result, torch.Tensor) and result.dtype == torch.float:
+            result = result.to(dtype=torch.float16)
+            self.env[n] = result
+            n.meta["tensor_meta"] = n.meta["tensor_meta"]._replace(dtype=torch.float16)
+
+        # Finally, restore the original env back to fp16 for any upconverted tensors.
+        for in_node, in_ten in orig_dtype_env:
+            self.env[in_node] = in_ten
+
+        return result
+
+    def run_embedding_bag(self, n: torch.fx.Node) -> Any:
+        """
+        EmbeddingBag with XL Weights of shape (num_embeddings, embedding_dim)
+        are replaced with smaller proxies of shape
+        (acc_ops.PROXY_EMBEDDING_SIZE, embedding_dim) during tracing. This can
+        cause index out of bounds issues when sample inputs lead to the
+        embedding bag op indexing into the first dimension of the weight tensor
+        which it expects to be bigger than it is during tracing.
+        """
+        if n.target == acc_ops.embedding_bag:
+            indices = n.kwargs["input"]
+        else:
+            indices = n.kwargs["indices"]
+
+        # Replace indices with zeros of same shape and dtype
+        indices_tensor = self.env[indices]
+        indices_zeros = torch.zeros_like(indices_tensor, dtype=indices_tensor.dtype)
+        self.env[indices] = indices_zeros
+
+        # Run node
+        result = super().run_node(n)
+
+        # Restore indices
+        self.env[indices] = indices_tensor
+
+        return result

--- a/olla/acc_tracer/acc_tracer.py
+++ b/olla/acc_tracer/acc_tracer.py
@@ -1,0 +1,630 @@
+import ast
+import builtins
+import copy
+import inspect
+import logging
+import textwrap
+import warnings
+from types import FunctionType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+import torch
+import torch.jit as jit
+import torch.nn as nn
+from torch._sources import normalize_source_lines
+from torch.fx import Graph, Tracer
+from torch.fx.experimental.normalize import NormalizeArgs
+from torch.fx.node import Argument, Node, Target
+from torch.fx.passes import shape_prop
+
+from . import acc_normalizer, acc_ops, acc_shape_prop, acc_utils  # noqa: F401
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _get_exception_wrapper_attr_name(exc_type: Type[Exception]) -> str:
+    return f"_conditional_exception_wrapper_{exc_type.__name__}"
+
+
+class Acc_Rewriter(ast.NodeTransformer):
+    """
+    Take a FunctionType object representing a `forward` method, then
+    perform an AST rewrite to swap out nodes that are not symbolically
+    traceable with a callsite to the FX alternative.
+
+    To support swapping out an AST node, define a new `visit` method on
+    that node. For more details, see:
+    https://docs.python.org/3/library/ast.html#ast.NodeTransformer
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.exceptions_rewritten: Set[Type[Exception]] = set()
+        self.exceptions_bool_rewritten: Set[Type[Exception]] = set()
+
+    def rewrite(
+        self, fn: FunctionType
+    ) -> Tuple[FunctionType, Set[Type[Exception]], Set[Type[Exception]]]:
+
+        # Normalize the source lines
+        sourcelines, _ = inspect.getsourcelines(fn)
+        sourcelines = normalize_source_lines(sourcelines)
+        source = "".join(sourcelines)
+        normalized_str = textwrap.dedent(source)
+
+        # Rewrite the original AST
+        source_ast = ast.parse(normalized_str)
+        dest_ast = ast.fix_missing_locations(self.visit(source_ast))
+
+        # Pull out the compiled function from the newly-created Module
+        code = compile(dest_ast, "", "exec")
+        globals_dict = copy.copy(fn.__globals__)
+        keys_before = set(globals_dict.keys())
+        exec(code, globals_dict)  # noqa P204
+        new_keys = list(set(globals_dict.keys()) - keys_before)
+        assert len(new_keys) <= 1
+        fn_compiled = globals_dict[fn.__name__]
+
+        # Return the correct FunctionType object and the Exceptions that were
+        # rewritten during visit_If.
+        return fn_compiled, self.exceptions_rewritten, self.exceptions_bool_rewritten
+
+    def visit_Assert(self, node: ast.Assert):
+        """
+        Swap out the Assert node (Python's `assert`) with a callsite to the
+        symbolically-traceable torch._assert function
+        """
+        # Create the Call node
+        n = ast.parse("torch._assert()", mode="eval")
+        assert isinstance(n, ast.Expression)
+        call_node = n.body
+        assert isinstance(call_node, ast.Call)
+        msg = node.msg if node.msg else ast.Constant(value="", kind=None)
+        call_node.args = [node.test, msg]
+
+        # Ensure that the new node conforms to the Python AST grammar
+        expr_wrapper = ast.Expr(value=call_node)
+
+        # Return the new Call node to signify that we want to use it as
+        # a replacement for the original _assert node
+        return ast.copy_location(expr_wrapper, node)
+
+    def visit_If(self, if_node: ast.If):
+        """
+        Swap out the pattern `If(x): Raise(y)` with a ConditionalExceptionWrapper
+        specialized for the specific exception y. The specialized
+        ConditionalExceptionWrapper module will be added in the RewrittenModule.
+        Only works with builtin Exceptions, as we assume the signature of the
+        init for the Exception is a string.
+        """
+        raise_node = if_node.body[0]
+        if not isinstance(raise_node, ast.Raise):
+            return if_node
+
+        # Don't handle orelse for now.
+        # TODO: Move orelse to the body after calling ConditionalExceptionWrapper.
+        if len(if_node.orelse) != 0:
+            return if_node
+
+        def _reuse_loc(node):
+            return ast.copy_location(node, if_node)
+
+        # If the exception has a message then we expect the raise's exc to be a
+        # Call w/ a msg. Else if it's a exc Name then there's no msg to use.
+        node_for_exc = raise_node.exc
+        if isinstance(node_for_exc, ast.Name):
+            # E.g. `raise AssertionError`, i.e. without an exc_msg.
+            name_node_of_exc = node_for_exc
+            exc_msg = _reuse_loc(ast.Constant(None))
+        elif isinstance(node_for_exc, ast.Call):
+            # E.g. `raise AssertionError("error message")`
+            name_node_of_exc = node_for_exc.func  # type: ignore[assignment]
+            if not isinstance(name_node_of_exc, ast.Name):
+                return if_node
+            # Most assertions just take a single string arg, but some may not; skip
+            # handling such assertions for now.
+            if len(node_for_exc.args) != 1:
+                return if_node
+            exc_msg = node_for_exc.args[0]
+        else:
+            return if_node
+
+        # Convert what we expect is the name of the exception into its
+        # associated python class.
+        name_of_exc = name_node_of_exc.id
+        try:
+            exc_type = eval(name_of_exc)  # noqa P204
+        except Exception:
+            return if_node
+
+        # Check that we actually have a builtin exception.
+        if (
+            not issubclass(exc_type, Exception)
+            or getattr(getattr(exc_type, "__class__", None), "__module__", None)
+            != "builtins"
+        ):
+            return if_node
+
+        # We need a ConditionalExceptionWrapper specialized for every kind of
+        # exception, so add it to exceptions_rewritten to remember for later to
+        # add a specialized attr with it.
+        self.exceptions_rewritten.add(exc_type)
+
+        # From here we definitely should be able to do the replacement. Create a
+        # Call node to the ConditionalExceptionWrapper module we're replacing
+        # the If with, with args set as the If's condition and the string of the
+        # exception. The call to the self._conditional_exception_wrapper_*Error
+        # module is safe because the RewrittenModule will add it as an attr
+        # based on the returned exceptions_rewritten, and we assume we are
+        # currently modifying the AST of a method from a RewrittenModule.
+        exc_wrapper_node = ast.parse(
+            f"self.{_get_exception_wrapper_attr_name(exc_type)}()", mode="eval"
+        )
+        assert isinstance(exc_wrapper_node, ast.Expression)
+        exc_wrapper_call_node = exc_wrapper_node.body
+        assert isinstance(exc_wrapper_call_node, ast.Call)
+        if isinstance(if_node.test, ast.BoolOp) and isinstance(
+            if_node.test.op, ast.And
+        ):
+            self.exceptions_bool_rewritten.add(exc_type)
+            bool_wrapper_node = ast.parse(
+                f"self.{_get_exception_wrapper_attr_name(exc_type)}_bool()", mode="eval"
+            )
+            assert isinstance(exc_wrapper_node, ast.Expression)
+            bool_wrapper_call_node = bool_wrapper_node.body
+            assert isinstance(exc_wrapper_call_node, ast.Call)
+            bool_wrapper_call_node.args = if_node.test.values
+            exc_wrapper_call_node.args = [
+                _reuse_loc(bool_wrapper_call_node),
+                exc_msg,
+            ]
+        else:
+            exc_wrapper_call_node.args = [if_node.test, exc_msg]
+
+        # Ensure that the new node conforms to the Python AST grammar
+        expr_wrapper = _reuse_loc(ast.Expr(_reuse_loc(exc_wrapper_call_node)))
+
+        # Return the new node to signify that we want to use it as a replacement
+        # for the original `If x: Raise y` pattern.
+        return expr_wrapper
+
+
+class ConditionalExceptionWrapper(nn.Module):
+    """
+    This wrapper class is used to wrap conditional raising of exceptions during
+    rewriting. For example:
+
+    .. code-block:: python
+
+        if self.name != "x":
+            raise AssertionError(f"Name was not x: {self.name}")
+
+    Is rewritten into
+
+    .. code-block:: python
+
+        self._conditional_exception_wrapper_AssertionError(
+            self.name != "x", f"Name was not x: {self.name}"
+        )
+
+    Note that __init__ takes the Exception class that it is wrapping, while
+    forward takes the condition to check and the message for the exception.
+
+    """
+
+    # Mark as impure so that calls to it will not be removed during DCE.
+    _is_impure = True
+
+    def __init__(self, exc: Type[Exception]):
+        super().__init__()
+        self.exc = exc
+
+    def forward(self, cond: bool, msg: str):
+        if cond:
+            raise self.exc if msg is None else self.exc(msg)
+
+
+class ConditionalExceptionBoolCondWrapper(nn.Module):
+    """
+    This is a wrapper class to for boolean ops used inside conditionals
+    raising exceptions.
+    This currently only handles binary input cases for the `and` operator
+    at one level of depth
+    For example:
+
+    .. code-block:: python
+
+    if self.name != "x" and self.name != "y":
+        raise AssertionError(f"Name was not x: {self.name}")
+
+    rewrites the `self.name != "x" and self.name != "y"` with
+    a `_conditional_exception_wrapper_AssertionError_bool` as follows:
+
+    .. code-block:: python
+
+        self._conditional_exception_wrapper_AssertionError(
+            self._conditional_exception_wrapper_AssertionError_bool(self.name != "x" and self.name != "y"), f"Name was not x: {self.name}"
+        )
+    """
+
+    # Mark as impure so that calls to it will not be removed during DCE.
+    _is_impure = True
+
+    def __init__(self, op):
+        super().__init__()
+
+    def forward(self, *conds: Iterable):
+        return all(conds)
+
+
+# Custom tracer that traces to the functional level and rewrites asserts and
+# exceptions.
+class AccRewritingTracer(Tracer):
+    # Add an explicit check for mutable operations, which break symbolic tracing.
+    check_mutable_operations = True
+    # Disble proxying buffers, which currently breaks some quantization code
+    proxy_buffer_attributes = False
+
+    # Note: Treat ConditionalExceptionWrapper as a leaf so that we don't
+    # trace into it, because it contains control flow and raises an exception.
+    DEFAULT_LEAF_MODULE_LIST = {
+        ConditionalExceptionBoolCondWrapper,
+        ConditionalExceptionWrapper,
+        torch.nn.quantized.Linear,
+        torch.nn.quantized.Conv2d,
+        torch.nn.intrinsic.quantized.ConvReLU2d,
+        jit.ScriptModule,
+        jit.RecursiveScriptModule,
+    }
+
+    def is_leaf_module(self, m: nn.Module, mod_qual_name: str) -> bool:
+        return getattr(m, "_base_class_origin", type(m)) in self.leaf_module_list
+
+    def trace(
+        self,
+        root: nn.Module,
+        concrete_args: Optional[Dict[str, Any]] = None,
+        ast_rewriter_allow_list: Optional[Set] = None,
+        leaf_module_list: Optional[Set] = None,
+    ) -> Tuple[Graph, nn.Module]:
+        self.leaf_module_list = self.DEFAULT_LEAF_MODULE_LIST
+        if leaf_module_list:
+            self.leaf_module_list.update(leaf_module_list)
+        rewritten = _rewrite(root, ast_rewriter_allow_list, self.leaf_module_list)
+        return super().trace(rewritten, concrete_args), rewritten
+
+    # override TraceBase's method
+    def create_node(
+        self,
+        kind: str,
+        target: Target,
+        args: Tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        name: Optional[str] = None,
+        type_expr: Optional[Any] = None,
+    ) -> Node:
+        """
+        Inserts a graph node given target, args, kwargs, and name.
+
+        This method can be overridden to do extra checking, validation, or
+        modification of values used in node creation. For example, one might
+        want to disallow in-place operations from being recorded.
+        """
+
+        ## Hacky way to decide inplace ops
+        if type(target) != str:
+            name_target = target.__name__
+        else:
+            name_target = target
+
+        allow_list = ["and_", "or_"]  # python  operator.and_,  operator.or_
+        if (
+            name_target[-1] == "_"
+            and name_target[0] != "_"
+            and not (name_target in allow_list)
+            and kind != "placeholder"
+        ):
+            raise RuntimeError(
+                f"Tried to trace mutable operation {name_target}. FX only supports functional code"
+            )
+
+        return self.graph.create_node(kind, target, args, kwargs, name, type_expr)
+
+
+# List of modules that need rewriting to be supported for tracing.
+DEFAULT_REWRITE_ALLOW_LIST = {
+    nn.BatchNorm1d,
+    nn.BatchNorm2d,
+    nn.BatchNorm3d,
+}
+
+
+def _rewrite(
+    mod_to_rewrite: nn.Module,
+    allow_list: Optional[Set] = None,
+    leaf_module_list: Optional[Set] = None,
+) -> nn.Module:
+    if allow_list is None:
+        allow_list = DEFAULT_REWRITE_ALLOW_LIST
+    else:
+        allow_list = allow_list.union(DEFAULT_REWRITE_ALLOW_LIST)
+
+    if not leaf_module_list:
+        leaf_module_list = set()
+
+    # Rewrite this module's functions as well as all recursive modules'
+    # functions that are attrs of this moodule. Return the new, rewritten module
+    # hierarchy.
+    def rewrite_module(m: nn.Module):
+        if isinstance(m, jit.ScriptModule):
+            # ScriptModule cannot be rewritten, so bypass it. The issue is it
+            # requires explicitly calling its `__init__()`, calling
+            # `nn.Module.__init__()` in the derived `RewrittenModule` is not
+            # enough. And even if we init it we can't do much with it.
+            return m
+
+        # If m is an already-rewritten RewrittenModule, then use the original base class.
+        base_class: Type[nn.Module] = getattr(m, "_base_class_origin", type(m))
+
+        # Keep track of all the ConditionalExceptionWrappers that the
+        # Acc_Rewriter calls into in this module so we can add them in init
+        # below.
+        all_added_wrappers: Set[Type[Exception]] = set()
+        all_added_bool_wrappers: Set[Type[Exception]] = set()
+
+        # Note: Make this a subclass of our base class.
+        class RewrittenModule(base_class):  # type: ignore[valid-type, misc]
+            # Keep track of the base_class so that symbolic tracing can
+            # determine what kind of module this originally was later on.
+            _base_class_origin = base_class
+            # Add suffix to qualname so it's easier to debug the origin of this module.
+            __qualname__ = f"{base_class.__qualname__}__AccRewrittenModule"
+
+            # Write all of the non-dunder or special methods from base_class
+            # into RewrittenModule.
+            for method_name in dir(base_class):
+                method = getattr(base_class, method_name, None)
+                if method is None and method_name not in {"__doc__"}:
+                    _LOGGER.warning(
+                        f"{__qualname__} does not have attribute {method_name}"
+                    )
+
+                if builtins.type(method) is not FunctionType:
+                    continue
+
+                # Always skip rewriting dunder methods, as they haven't (yet) been
+                # problematic, and modifying them has caused issues previously.
+                if method_name.startswith("__") and method_name.endswith("__"):
+                    continue
+
+                # Only rewrite those Modules explicitly in the allow_list.
+                assert allow_list is not None
+                if base_class not in allow_list:
+                    vars()[method_name] = method
+                else:
+                    (
+                        vars()[method_name],
+                        added_wrappers,
+                        added_bool_wrappers,
+                    ) = Acc_Rewriter().rewrite(method)
+                    all_added_wrappers.update(added_wrappers)
+                    all_added_bool_wrappers.update(added_bool_wrappers)
+
+            def __init__(self, orig):
+                nn.Module.__init__(self)
+
+                # Iterate over all added exception wrappers and add
+                # ConditionalExceptionWrapper attrs for each.
+                for exc_type in all_added_wrappers:
+                    wrapper_name = _get_exception_wrapper_attr_name(exc_type)
+                    assert not hasattr(self, wrapper_name)
+                    setattr(
+                        self,
+                        wrapper_name,
+                        ConditionalExceptionWrapper(exc_type),
+                    )
+
+                for exc_type in all_added_bool_wrappers:
+                    wrapper_name = f"{_get_exception_wrapper_attr_name(exc_type)}_bool"
+                    assert not hasattr(self, wrapper_name)
+                    setattr(
+                        self,
+                        wrapper_name,
+                        ConditionalExceptionBoolCondWrapper(exc_type),
+                    )
+
+                # Recursively rewrite and copy all module attrs of this module.
+                for k, v in orig.__dict__.items():
+                    if k == "_modules":
+                        for mod_k, mod_v in v.items():
+                            if getattr(mod_v, "_base_class_origin", type(mod_v)) in leaf_module_list:  # type: ignore[operator]
+                                _LOGGER.info(
+                                    f"Skip rewriting leaf module {type(mod_v)}"
+                                )
+                                self._modules[mod_k] = mod_v
+                            else:
+                                self._modules[mod_k] = rewrite_module(mod_v)
+                    else:
+                        self.__dict__[k] = v
+
+        # Add suffix to name so it's easier to debug the origin of this module.
+        RewrittenModule.__name__ = f"{base_class.__name__}__AccRewrittenModule"
+        return RewrittenModule(m)
+
+    return rewrite_module(mod_to_rewrite)
+
+
+def _remove_assertions(gm: torch.fx.GraphModule) -> bool:
+    """
+    Unconditionally removes all assertions found in GraphModule gm.
+    Returns whether the graph is modified.
+    """
+    changed = False
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target == torch._assert:
+            gm.graph.erase_node(node)
+            changed = True
+    return changed
+
+
+def _remove_exceptions(gm: torch.fx.GraphModule) -> bool:
+    """
+    Unconditionally removes all call_modules to ConditionalExceptionWrappers
+    found in GraphModule gm. Returns whether the graph is modified.
+    """
+    changed = False
+    for node in reversed(gm.graph.nodes):
+        if node.op == "call_module" and (
+            isinstance(gm.get_submodule(node.target), ConditionalExceptionWrapper)
+            or isinstance(
+                gm.get_submodule(node.target), ConditionalExceptionBoolCondWrapper
+            )
+        ):
+            gm.graph.erase_node(node)
+            changed = True
+    return changed
+
+
+def _replace_tensor_meta_with_rank(gm: torch.fx.GraphModule):
+    for node in gm.graph.nodes:
+        if node.op != "output" and "tensor_meta" in node.meta:
+            node.meta["tensor_rank"] = acc_utils.map_tensor_metadata(
+                node.meta["tensor_meta"], lambda x: len(x.shape)
+            )
+            del node.meta["tensor_meta"]
+
+
+def rewriter_base_trace(mod, ast_rewriter_allow_list, leaf_module_list):
+    rewritten_graph, rewritten_mod = AccRewritingTracer().trace(
+        mod,
+        ast_rewriter_allow_list=ast_rewriter_allow_list,
+        leaf_module_list=leaf_module_list,
+    )
+
+    assert isinstance(rewritten_mod, nn.Module)
+    # Note: use the rewritten_mod here as the root. This is necessary because
+    # RewrittenModule includes a new module for the ConditionalExceptionWrapper.
+    return torch.fx.GraphModule(rewritten_mod, rewritten_graph)
+
+
+def trace(
+    mod: nn.Module,
+    sample_inputs: Sequence[Any],
+    remove_assertions: bool = True,
+    remove_exceptions: bool = True,
+    use_acc_normalization: bool = True,
+    use_acc_shape_inference: bool = True,
+    ast_rewriter_allow_list: Optional[Set[Type[nn.Module]]] = None,
+    leaf_module_list: Optional[Set[Type[nn.Module]]] = None,
+    acc_normalization_block_list: Optional[
+        Set[Tuple[str, Union[str, Callable]]]
+    ] = None,
+) -> torch.fx.GraphModule:
+    """
+    Performs tracing and arg normalization specialized for accelerator lowering.
+
+    It first rewrites the AST of the module's methods (and all attr methods
+    recursively) to transform un-tracable parts of the module to make them
+    traceable.
+
+    It then traces to the functional level so that optimizations and backend
+    accelerator importers have the ability to see and/or change inputs to each
+    op.
+
+    It then removes assertions and exception wrappers found during symbolic
+    tracing if requested based on remove_assertions and remove_exceptions
+
+    Dead code is then eliminated, which will e.g. remove any nodes that were
+    only used by assertions or exceptions if they were removed.
+
+    It then performs normalization on args/kwargs, aligning any arg that can be
+    moved to kwarg to be so, and then making default values explicit.
+
+    Args:
+
+        mod (Module): The module to transform and trace.
+
+        sample_inputs (Tuple[Union[torch.Tensor, List[torch.Tensor]]]):
+                Sample inputs with which to run shape prop.
+
+        remove_assertions (bool): Whether to remove assertion nodes from
+                                    the graph after symbolic tracing.
+
+        remove_exceptions (bool): Whether to remove exception wrapper nodes
+                                    from the graph after symbolic tracing.
+
+        use_acc_normalization (bool): Whether to use acc-specific
+                                        normalization to all acc_ops.
+
+        use_acc_shape_inference (bool): Whether to run shape inference after normalization.
+
+        ast_rewriter_allow_list (Optional[Set[nn.Module]]): Optional allow list of
+                                            modules that need AST rewriting.
+
+        leaf_module_list (Optional[Set[nn.Module]]): Optional leaf module list where
+                                            modules will not be traced into.
+
+        acc_normalization_block_list (Optional[Set[Tuple[str, Union[str, Callable]]]]):
+                                    Optional set of (op, target) pairs to not apply acc
+                                    normalization to. Just like the register_acc_op decarators,
+                                    the target can either be a string (e.g. for op == "call_method")
+                                    or a callable (e.g. for op == "call_function").
+    """
+    if mod.training:
+        warnings.warn(
+            "acc_tracer does not support currently support models for training."
+            " Calling eval on model before tracing."
+        )
+        mod.eval()
+
+    assert isinstance(sample_inputs, (list, tuple))
+
+    # Rewrite the module to make it symbolic traceable, and then trace it.
+    traced = rewriter_base_trace(mod, ast_rewriter_allow_list, leaf_module_list)
+
+    # Now remove all assertions and exceptions if requested.
+    if remove_assertions:
+        _remove_assertions(traced)
+    if remove_exceptions:
+        _remove_exceptions(traced)
+
+    # Cleanup any dead code from the original module as well as resulting dead
+    # nodes after removing assertions and exceptions.
+    traced.graph.eliminate_dead_code()
+    traced.recompile()
+
+    # Run shape prop to add node.meta["type"] to nodes, needed for NormalizeArgs.
+    acc_shape_prop.AccShapeProp(traced).propagate(*sample_inputs)
+    # Swap out tensor_meta for tensor_rank, because we don't actually want to rely on
+    # tensor_meta yet for normalization/lowering, though rank shouldn't change.
+    _replace_tensor_meta_with_rank(traced)
+    # Now normalize args/kwargs to make default values visible. Leave args/kwargs as
+    # they were, since all-kwarg normalization is broken, and we don't need it anyway.
+    traced = NormalizeArgs(traced, normalize_to_only_use_kwargs=False).transform()
+
+    # Normalize to acc-specialized wrappers for consistency across op naming and
+    # ensuring all kwarg usage.
+    if use_acc_normalization:
+        acc_normalizer.normalize(
+            traced, acc_normalization_block_list=acc_normalization_block_list
+        )
+
+    traced.recompile()
+
+    # Run shape prop to again to populate tensor_meta after normalize.
+    if use_acc_shape_inference:
+        acc_shape_prop.AccShapeProp(traced).propagate(*sample_inputs)
+
+    return traced

--- a/olla/acc_tracer/acc_utils.py
+++ b/olla/acc_tracer/acc_utils.py
@@ -1,0 +1,201 @@
+import inspect
+import json
+import logging
+import os
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.fx
+from torch.fx.graph_module import GraphModule
+from torch.fx.immutable_collections import immutable_dict, immutable_list
+from torch.fx.node import _get_qualified_name
+from torch.fx.passes import graph_drawer
+from torch.fx.passes.shape_prop import TensorMetadata
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def get_target_from_module(mod: torch.nn.Module, target: str):
+    """
+    Gets `target` from `mod` and returns it. If `target` is empty then returns `mod.`
+    """
+    if target == "":
+        return mod
+
+    target_atoms = target.split(".")
+    curr_obj = mod
+    for i, atom in enumerate(target_atoms):
+        if not hasattr(curr_obj, atom):
+            raise RuntimeError(
+                f"Node referenced nonexistent target '{'.'.join(target_atoms[:i])}'; "
+                f" original whole target: '{target}'"
+            )
+        curr_obj = getattr(curr_obj, atom)
+    return curr_obj
+
+
+def get_attr(node: torch.fx.Node) -> Any:
+    """
+    Returns the underlying attr for a given node which
+    must be of type get_attr.
+    """
+    assert node.op == "get_attr", "Expected a get_attr node"
+    return get_target_from_module(node.graph.owning_module, str(node.target))
+
+
+def is_acc_op(node_or_target: Union[Callable, torch.fx.Node]) -> bool:
+    """
+    Returns whether `node_or_target` is an acc_op. If it's a node, then checks whether
+    it's a call_function target is from the acc_ops module. Otherwise it's already
+    the target, which is similarly checked to see if it's from the acc_ops module.
+    """
+    if isinstance(node_or_target, torch.fx.Node):
+        # All acc_ops are call_functions.
+        if node_or_target.op != "call_function":
+            return False
+        target = node_or_target.target
+    else:
+        target = node_or_target
+    return "acc_ops" in target.__module__
+
+
+def is_acc_op_with_kwarg(
+    node_or_target: Union[Callable, torch.fx.Node], kwarg: str
+) -> bool:
+    """
+    Helper that inspects `node_or_target` and returns whether it is an acc_op node
+    (or a target for an acc_op) that has an arg signature that includes `kwarg`.
+    """
+    if not is_acc_op(node_or_target):
+        return False
+
+    target = (
+        node_or_target.target
+        if isinstance(node_or_target, torch.fx.Node)
+        else node_or_target
+    )
+    assert not isinstance(target, str)
+    return kwarg in inspect.signature(inspect.unwrap(target)).parameters
+
+
+def build_raw_tensor_meta(
+    shape=None,
+    dtype=None,
+    requires_grad=None,
+    stride=None,
+    memory_format=None,
+    is_quantized=None,
+    qparams=None,
+):
+    return TensorMetadata(**locals())
+
+
+def draw_graph(traced: torch.fx.GraphModule, fname: str, figname: str = "fx_graph"):
+    base, ext = os.path.splitext(fname)
+    if not ext:
+        ext = ".svg"
+    _LOGGER.info(f"Writing FX graph to file: {base}{ext}")
+    g = graph_drawer.FxGraphDrawer(traced, figname)
+    x = g.get_main_dot_graph()
+    try:
+        getattr(x, "write_" + ext.lstrip("."))(fname)
+    except OSError as e:
+        _LOGGER.error(f"Failed to write the FX graph due to: {e}")
+
+
+def get_model_info_str(gm: torch.fx.GraphModule, header: Optional[str] = None):
+    """
+    Print out info of the provided `gm`.
+    If `header` is provided then it's included in the printed string.
+    """
+    ops_and_counts: Dict[Callable, int] = {}
+    placeholder_count = get_attr_count = call_method_count = call_module_count = 0
+    for node in gm.graph.nodes:
+        if node.op == "call_function":
+            ops_and_counts[node.target] = ops_and_counts.get(node.target, 0) + 1
+        elif node.op == "placeholder":
+            placeholder_count += 1
+        elif node.op == "get_attr":
+            get_attr_count += 1
+        elif node.op == "call_method":
+            call_method_count += 1
+        elif node.op == "call_module":
+            call_module_count += 1
+        elif node.op == "output":
+            output_count = len(node.args[0]) if isinstance(node.args[0], tuple) else 1
+        else:
+            raise RuntimeError(f"Unknown node found: {node.format_node()}")
+
+    header = "" if header is None else f" [{header}]"
+    model_info_str = f"Model Info{header}:\n"
+    model_info_str += f"> placeholder: {placeholder_count}\n"
+    model_info_str += f"> get_attr: {get_attr_count}\n"
+    model_info_str += f"> output: {output_count}\n"
+    if call_module_count != 0:
+        model_info_str += f"> WARNING: call_module: {call_module_count}"
+    if call_method_count != 0:
+        model_info_str += f"> WARNING: call_method: {call_method_count}"
+
+    # Sort and print all the other ops. Sort so it's deterministic between runs and
+    # easier to parse.
+    pretty_ops_and_counts: List[Tuple[str, int]] = []
+    for op, count in ops_and_counts.items():
+        pretty_ops_and_counts.append((_get_qualified_name(op), count))
+    pretty_ops_and_counts.sort()
+    for op_str, count in pretty_ops_and_counts:
+        model_info_str += f"> {op_str}: {count}\n"
+
+    return model_info_str
+
+
+def get_unique_attr_name_in_module(mod_traced: torch.fx.GraphModule, name: str) -> str:
+    """
+    Make sure the name is unique (in a module) and can represents an attr.
+    """
+    # Delete all characters that are illegal in a Python identifier.
+    name = re.sub("[^0-9a-zA-Z_]+", "_", name)
+    if name[0].isdigit():
+        name = f"_{name}"
+    # Now make sure it is in fact unique to the module by incrementing suffix value.
+    while hasattr(mod_traced, name):
+        match = re.match(r"(.*)_(\d+)$", name)
+        if match is None:
+            name = name + "_1"
+        else:
+            base, num = match.group(1, 2)
+            name = f"{base}_{int(num) + 1}"
+
+    return name
+
+
+def map_tensor_metadata(a: Any, fn: Callable):
+    """
+    Map some `fn` to `a`, where `a` is either a TensorMetadata, or else a tuple/list/dict
+    recursively containing TensorMetadata.
+    """
+    if isinstance(a, int):
+        return 1
+    elif isinstance(a, TensorMetadata):
+        return fn(a)
+    elif isinstance(a, tuple):
+        return tuple(map_tensor_metadata(elem, fn) for elem in a)
+    elif isinstance(a, dict):
+        return immutable_dict(
+            {name: map_tensor_metadata(elem, fn) for name, elem in a.items()}
+        )
+    assert isinstance(
+        a, list
+    ), f"Only supporting tuple/list/TensorMetadata, but found {type(a)}"
+    return immutable_list(map_tensor_metadata(elem, fn) for elem in a)
+
+
+def get_tensor_meta(node: torch.fx.Node) -> TensorMetadata:
+    tensor_meta = node.meta.get("tensor_meta")
+
+    if not tensor_meta:
+        raise RuntimeError(
+            f"Node has no tensor metadata associated with it! "
+            f"Check that shape propagation has run. {node.format_node()}"
+        )
+    return tensor_meta

--- a/olla/dataflow_graph.py
+++ b/olla/dataflow_graph.py
@@ -1,0 +1,1264 @@
+import functools
+import math
+import re
+from collections import defaultdict
+from typing import List
+
+import networkx as nx
+from graphviz import Digraph
+
+
+# Each node corresponds to a computation in the model. Each node can have
+# fanin (resp fanout) edges, which correspond to the tensor(s) fed to (resp
+# produced) by the node.
+class Node:
+    def __init__(self, name=None, op_type=None, size=0, read_only=False, time=None):
+        self.name = name
+        self.op_type = op_type
+        self.size = size
+        self.read_only = read_only
+        self.fanin = []
+        self.fanout = []
+        self.time = time
+
+    def __repr__(self):
+        val = self.name + " (" + str(self.op_type) + ")"
+        if self.size > 0:
+            val += " [" + str(self.size) + "]"
+        return val
+
+    def is_stateful(self):
+        return (
+            self.size > 0
+            or self.op_type == "stateful_node"
+            or self.op_type == "stateful_node_sink"
+        )
+
+    def access_stateful_node(self):
+        for edge in self.fanin:
+            for node in edge.sources:
+                if node.is_stateful():
+                    return True
+        return False
+
+
+# Each edge corresponds to a tensor in the model. An edge has exactly one
+# source node, which is the operation that produced the corresponding value.
+class Edge:
+    def __init__(
+        self,
+        source,
+        sinks,
+        size,
+        name=None,
+        mem_space=None,
+        tile_id=None,
+        group_id=None,
+    ):
+        self.name = name
+        self.size = size
+        self.source = source
+        self.sinks = sinks
+        self.mem_space = mem_space
+        self.tile_id = tile_id
+        self.group_id = group_id
+
+    def __repr__(self):
+        return (
+            self.name
+            + ": "
+            + str(self.source)
+            + " -> "
+            + str(self.sinks)
+            + " size="
+            + str(self.size)
+        )
+
+    def add_sink(self, node):
+        self.sinks.append(node)
+        node.fanin.append(self)
+
+    def add_sinks(self, nodes):
+        for node in nodes:
+            self.add_sink(node)
+
+    def add_source(self, node):
+        assert self.source is None, "Edge class can only have one source"
+        self.source = node
+
+    def is_stateful(self):
+        return self.source.is_stateful()
+
+    @property
+    def sources(self):
+        return iter([self.source])
+
+
+# Each MultiSourceEdge corresponds to a tensor in the model. An edge has at least one
+# source node, which correspond to the operation(s) that produced the tensor value.
+# Each has also has at least one sink. Each sink corresponds to a node that
+# consumes the corresponding value.
+class MultiSourceEdge:
+    def __init__(
+        self,
+        sources,
+        sinks,
+        size,
+        name=None,
+        mem_space=None,
+        tile_id=None,
+        group_id=None,
+    ):
+        self.name = name
+        self.size = size
+        self.sources = sources
+        self.sinks = sinks
+        self.mem_space = mem_space
+        self.tile_id = tile_id
+        self.group_id = group_id
+
+    def __repr__(self):
+        return f"MultiSourceEdge {self.name}, size:{self.size}, mem_space:{self.mem_space}, tile_id:{self.tile_id} group_id:{self.group_id} sources:{self.sources} sinks:{self.sinks}"
+
+    def add_source(self, node):
+        self.sources.append(node)
+        node.fanout.append(self)
+
+    def add_sources(self, nodes):
+        for node in nodes:
+            self.add_source(node)
+
+    def add_sink(self, node):
+        self.sinks.append(node)
+        node.fanin.append(self)
+
+    def add_sinks(self, nodes):
+        for node in nodes:
+            self.add_sink(node)
+
+    def is_stateful(self):
+        if len(self.sources) != 1:
+            return False
+        return self.sources[0].is_stateful()
+
+
+# A directed hypergraph that models the computation. Loops are forbidden.
+# Each model input must be represented by a node with no fanin edge
+# Each model output must be represented by a node with no fanout edge.
+class Graph:
+    def __init__(self, name=""):
+        self.name = name
+        self.nodes = {}
+        self.edges = {}
+        self.canonical = False
+
+    def add_node(self, name=None, op_type=None, size=0, read_only=False):
+        if name is None:
+            name = str(len(self.nodes) + 1)
+        assert type(name) is str
+        assert name not in self.nodes
+        self.nodes[name] = Node(name, op_type, size, read_only)
+        return self.nodes[name]
+
+    def add_edge(
+        self,
+        sources,
+        sinks,
+        size,
+        name=None,
+        mem_space=None,
+        tile_id=None,
+        group_id=None,
+        mutable=True,
+    ):
+        if name is None:
+            name = str(len(self.edges) + 1)
+        assert type(name) is str
+        assert name not in self.edges
+
+        if not mutable and len(sources) == 1:
+            edge = Edge(
+                sources[0],
+                sinks,
+                size,
+                name,
+                mem_space=mem_space,
+                tile_id=tile_id,
+                group_id=group_id,
+            )
+        else:
+            edge = MultiSourceEdge(
+                sources,
+                sinks,
+                size,
+                name,
+                mem_space=mem_space,
+                tile_id=tile_id,
+                group_id=group_id,
+            )
+        self.edges[name] = edge
+        for node in sources:
+            node.fanout.append(edge)
+        for node in sinks:
+            node.fanin.append(edge)
+
+        return edge
+
+    def find_node(self, name: str = None, op_type: str = None) -> Node:
+        nodes = self.find_nodes(name, op_type, max_nodes=1)
+        if len(nodes) > 0:
+            return nodes[0]
+        else:
+            return None
+
+    def find_nodes(
+        self, name: str = None, op_type: str = None, max_nodes: int = None
+    ) -> List[Node]:
+        if not name:
+            raise ValueError("name not provided.")
+
+        name = name.replace("*", ".*")
+        regex = re.compile(f"^{name}$")
+        matching_node_names = list(filter(regex.match, self.nodes.keys()))
+
+        if op_type:
+            return [
+                self.nodes[key]
+                for key in matching_node_names
+                if self.nodes[key].op_type == op_type
+            ][:max_nodes]
+        else:
+            return [self.nodes[key] for key in matching_node_names][:max_nodes]
+
+    def find_edge(
+        self, name: str = None, mem_space=None, tile_id=None, group_id=None
+    ) -> Edge:
+        edges = self.find_edges(name, mem_space, tile_id, group_id, max_edges=1)
+        if len(edges) > 0:
+            return edges[0]
+        else:
+            return None
+
+    def find_edges(
+        self,
+        name: str = None,
+        mem_space=None,
+        tile_id=None,
+        group_id=None,
+        max_edges: int = None,
+    ) -> List[Edge]:
+        def filter_edges(edge):
+            if_mem_space = edge.mem_space == mem_space
+            if_tile_id = edge.tile_id == tile_id
+            if_group_id = edge.group_id == group_id
+
+            return if_mem_space and if_tile_id and if_group_id
+
+        named_edges = []
+        if name:
+            name = name.replace("*", ".*")
+            regex = re.compile(f"^{name}$")
+            matching_edge_names = list(filter(regex.match, self.edges.keys()))
+            named_edges = [self.edges[key] for key in matching_edge_names]
+
+        filter_params = list(filter(filter_edges, named_edges or self.edges.values()))
+
+        return filter_params[:max_edges]
+
+    def delete_edge(self, edge):
+        # print("Deleting edge " + str(edge))
+
+        for node in edge.sources:
+            node.fanout.remove(edge)
+
+        for node in edge.sinks:
+            node.fanin.remove(edge)
+
+        del self.edges[edge.name]
+
+    def delete_node(self, node):
+        # print("Deleting node " + str(node))
+
+        edges_to_delete = set()
+        for edge in node.fanin:
+            # print("Removing " + str(node) + " from the sinks of " + str(edge))
+            if len(edge.sinks) == 1:
+                edges_to_delete.add(edge)
+            else:
+                edge.sinks.remove(node)
+
+        for edge in node.fanout:
+            if isinstance(edge, MultiSourceEdge):
+                if len(edge.sources) == 1:
+                    edges_to_delete.add(edge)
+                else:
+                    edge.sources.remove(node)
+            else:
+                assert edge.source == node
+                edges_to_delete.add(edge)
+
+        for e in edges_to_delete:
+            self.delete_edge(e)
+        del self.nodes[node.name]
+
+    # Convert all the MultiSourceEdges to regular Edges.
+    def canonicalize(self):
+        if self.canonical:
+            return
+
+        canonical_edges = {}
+        for name, e in self.edges.items():
+            assert name == e.name
+            if isinstance(e, Edge):
+                canonical_edges[name] = e
+
+            elif len(e.sources) == 1:
+
+                new_edge = Edge(
+                    e.sources[0],
+                    e.sinks,
+                    e.size,
+                    e.name,
+                    mem_space=e.mem_space,
+                    tile_id=e.tile_id,
+                    group_id=e.group_id,
+                )
+                canonical_edges[name] = new_edge
+                e.sources[0].fanout.remove(e)
+                e.sources[0].fanout.append(new_edge)
+                for snk in e.sinks:
+                    snk.fanin.remove(e)
+                    snk.fanin.append(new_edge)
+            else:
+                name = "allocate_" + e.name
+                node = Node(name, op_type="allocate_tensor")
+                self.nodes[name] = node
+
+                # combined_no_dup = e.sinks + list(set(e.sources) - set(e.sinks))
+                assert set(e.sources).isdisjoint(set(e.sinks))
+                combined_no_dup = e.sinks + e.sources
+
+                new_edge = Edge(
+                    node,
+                    combined_no_dup,
+                    e.size,
+                    name=name,
+                    mem_space=e.mem_space,
+                    tile_id=e.tile_id,
+                    group_id=e.group_id,
+                )
+
+                canonical_edges[name] = new_edge
+                node.fanout.append(new_edge)
+                for src in e.sources:
+                    if new_edge not in src.fanin:
+                        src.fanin.append(new_edge)
+                for snk in e.sinks:
+                    if new_edge not in snk.fanin:
+                        snk.fanin.append(new_edge)
+                    snk.fanin.remove(e)
+
+                for src in e.sources:
+                    name = src.name + "_" + e.name
+                    new_edge = Edge(
+                        src,
+                        e.sinks,
+                        0,
+                        name=name,
+                        mem_space=e.mem_space,
+                        tile_id=e.tile_id,
+                        group_id=e.group_id,
+                    )
+                    canonical_edges[name] = new_edge
+                    src.fanout.append(new_edge)
+                    src.fanout.remove(e)
+                    for n in e.sinks:
+                        n.fanin.append(new_edge)
+
+        self.edges = canonical_edges
+
+        # Handle stateful nodes
+        new_nodes = []
+        for n in self.nodes.values():
+            if n.size > 0 and len(n.fanout) > 0:
+                assert len(n.fanout) == 1
+                edge = n.fanout[0]
+                edge.size += n.size
+                snk_node = Node(n.name + "_snk", op_type="stateful_node_sink")
+                new_nodes.append((snk_node.name, snk_node))
+                edge.add_sink(snk_node)
+                n.size = 0
+                n.op_type = "stateful_node"
+
+        self.nodes.update(new_nodes)
+
+        self.canonical = True
+
+    # TODO: should we merge this into the `prune()` function?
+    def remove_dead_nodes(self):
+        nodes_to_delete = set()
+
+        for n in self.nodes.values():
+            if len(n.fanin) == 0 and len(n.fanout) == 0:
+                nodes_to_delete.add(n)
+
+        for n in nodes_to_delete:
+            self.delete_node(n)
+
+        return
+
+    # Remove unnecessary nodes from the graph
+    def prune(self, aggressive=False):
+        # The graph should be pruned before canonicalization
+        assert not self.canonical
+
+        nodes_to_delete = set()
+        for e in self.edges.values():
+            if not isinstance(e, MultiSourceEdge):
+                continue
+            if len(e.sources) == 1:
+                continue
+            deletion_candidates = []
+            for n in e.sources:
+                # Undriven copy or fill node
+                if len(n.fanin) == 0 and (
+                    n.op_type == "turing::copy" or n.op_type == "turing::fill"
+                ):
+                    deletion_candidates.append(n)
+
+            # Delete these undriven copy/fill nodes as long as this will leave
+            # at least one source for the edge.
+            if len(deletion_candidates) < len(e.sources):
+                for n in deletion_candidates:
+                    nodes_to_delete.add(n)
+
+        for n in nodes_to_delete:
+            self.delete_node(n)
+
+        if not aggressive:
+            return
+
+        nodes_to_delete = set()
+        for e in self.edges.values():
+            if not isinstance(e, MultiSourceEdge):
+                continue
+            # Check for the following pattern and remove the copy node:
+            # Op1 ________________ Op2
+            #     \____ Copy ____/
+            if len(e.sources) != 2:
+                continue
+            if e.sources[0].op_type == "turing::copy":
+                copy_node = e.sources[0]
+                op1_node = e.sources[1]
+            elif e.sources[1].op_type == "turing::copy":
+                copy_node = e.sources[1]
+                op1_node = e.sources[0]
+            else:
+                continue
+            if (
+                len(copy_node.fanin) == 1
+                and copy_node.fanin[0].size == 0
+                and len(copy_node.fanin[0].sources) == 1
+                and copy_node.fanin[0].sources[0] == op1_node
+            ):
+                nodes_to_delete.add(copy_node)
+
+        for n in nodes_to_delete:
+            self.delete_node(n)
+
+        nodes_to_delete = set()
+        for e in self.edges.values():
+            if not isinstance(e, MultiSourceEdge):
+                continue
+            # Check for the following pattern and a keep single representative
+            # copy node:
+            # Op1 _______Op2_______ Op3
+            #     \____ Copy1 ____/
+            #     \____ Copy2 ____/
+            #     \____ Copy3 ____/
+            representative_copy = None
+            for n in e.sources:
+                if n.op_type != "turing::copy":
+                    continue
+                if not representative_copy:
+                    representative_copy = n
+                else:
+                    if (
+                        n.fanin == representative_copy.fanin
+                        and n.fanout == representative_copy.fanout
+                    ):
+                        nodes_to_delete.add(n)
+
+        for n in nodes_to_delete:
+            self.delete_node(n)
+
+    # Remove unnecessary nodes from the graph
+    def prune_old(self, aggressive=False):
+        assert self.canonical
+        nodes_to_delete = set()
+        for n in self.nodes.values():
+            prune = len(n.fanout) > 0
+            for f in n.fanout:
+                if f.size > 0:
+                    prune = False
+                    break
+            for f in n.fanin:
+                if aggressive and f.source.op_type == "allocate_tensor":
+                    continue
+                if f.size > 0:
+                    prune = False
+                    break
+            # All the fanin and fanout edges have size 0: the node
+            # has no impact on the memory footprint and can be deleted
+            if prune:
+                nodes_to_delete.add(n)
+
+        for n in nodes_to_delete:
+            for fanin in n.fanin:
+                for fanout in n.fanout:
+                    for snk in fanout.sinks:
+                        if not self.is_in_transitive_fanin(fanin.source, snk, n):
+                            self.add_edge([fanin.source], [snk], size=0, mutable=False)
+            self.delete_node(n)
+
+        if self.canonical:
+            self.canonical = False
+            self.canonicalize()
+
+    # Constraint allocations to make sure they happen as late as possible since
+    # there is no need for them to happen any sooner than that.
+    def constrain_allocations(self):
+        dom_tree = self.build_dominator_tree()
+        for n in self.nodes.values():
+            if n.op_type != "allocate_tensor":
+                continue
+            afters = []
+            seen = set()
+            for fo in n.fanout:
+                for s in fo.sinks:
+                    if s not in seen:
+                        afters.append(s)
+                        seen.add(s)
+            dom = dom_tree.lowest_common_ancestor(afters)
+            if dom:
+                self.add_edge(
+                    [dom], [n], 0, "constrain_" + n.name + "_after_" + dom.name
+                )
+
+        if self.canonical:
+            self.canonical = False
+            self.canonicalize()
+
+    def constrain_weight_updates(self):
+        fwd_levels = self.build_levelization()
+        bwd_levels = self.build_reverse_levelization()
+
+        # print("CONSTRAINING WEIGHT UPDATES")
+
+        for n in self.nodes.values():
+            if len(n.fanout) > 0:
+                continue
+            if n.is_stateful():
+                continue
+            if not n.access_stateful_node():
+                continue
+
+            # print(f"Found interesting node {n.name} at min fwd level {fwd_levels[n]}")
+            min_fwd_level = fwd_levels[n]
+            max_bwd_level = 0
+            best_candidate_node = None
+            candidate_sources = set([n])
+            cache = {}
+            while not best_candidate_node and len(candidate_sources) > 0:
+                candidate_sources = self._generate_candidate_sources(candidate_sources)
+                # print(f"  CANDIDATE SOURCES {candidate_sources}")
+                for src in candidate_sources:
+                    candidate, level = self._find_candidate_fwd(
+                        src, fwd_levels, bwd_levels, min_fwd_level, cache
+                    )
+                    # print(f"    CANDIDATE ANCHOR {candidate} at {level}")
+                    if level > max_bwd_level:
+                        max_bwd_level = level
+                        best_candidate_node = candidate
+
+                if best_candidate_node:
+                    # print(f"  ADDING EDGE FROM {n.name} to {best_candidate_node.name}")
+                    self.add_edge(
+                        [n],
+                        [best_candidate_node],
+                        size=0,
+                        name=n.name + "_forced_early",
+                    )
+
+        if self.canonical:
+            self.canonical = False
+            self.canonicalize()
+
+    def constrain_tensor_generators(self):
+        fwd_levels = self.build_levelization()
+
+        for n in self.nodes.values():
+            if len(n.fanin) > 0:
+                continue
+            if not n.name.startswith("empty") and not n.name.startswith(
+                "new_empty_strided"
+            ):
+                continue
+
+            # print(f"  CONSTRAINING TENSOR GENERATOR NODE {n.name}")
+
+            candidates = self._find_candidates_bwd(n)
+
+            best_candidate = None
+            max_level = len(self.nodes)
+            for c in candidates:
+                if fwd_levels[c] < max_level:
+                    max_level = fwd_levels[c]
+                    best_candidate = c
+            if best_candidate:
+                # print(f"  ADDING EDGE FROM {best_candidate.name} to {n}")
+                self.add_edge(
+                    [best_candidate], [n], size=0, name=n.name + "_forced_late"
+                )
+
+        if self.canonical:
+            self.canonical = False
+            self.canonicalize()
+
+    def constrain_relative_ordering(self, node_ordering, linearize=False):
+        min_timestep = math.inf
+        max_timestep = 0
+        per_timestep = defaultdict(lambda: [])
+        for n, t in node_ordering.items():
+            if n.is_stateful():
+                continue
+            min_timestep = min(min_timestep, t)
+            max_timestep = max(max_timestep, t)
+            per_timestep[t].append(n)
+
+        if linearize:
+            linearized = {}
+            current_timestep = min_timestep
+            for ts in range(min_timestep, max_timestep + 1):
+                for n in per_timestep[ts]:
+                    linearized[current_timestep] = [n]
+                    current_timestep += 1
+            per_timestep = linearized
+            max_timestep = current_timestep - 1
+
+        previous_ts = min_timestep
+        assert len(per_timestep[previous_ts]) > 0
+        for ts in range(min_timestep + 1, max_timestep + 1):
+            if len(per_timestep[ts]) == 0:
+                continue
+            for src in per_timestep[previous_ts]:
+                needed_snks = []
+                name = f"run_{src.name}_before"
+                for snk in per_timestep[ts]:
+                    edge_already_exists = False
+                    for fi in snk.fanin:
+                        for s in fi.sources:
+                            if s == src:
+                                edge_already_exists = True
+                                break
+                    if not edge_already_exists:
+                        needed_snks.append(snk)
+                        name += f"_{snk.name}"
+                if len(needed_snks) > 0:
+                    name.replace(" ", "_")
+                    self.add_edge([src], needed_snks, size=0, name=name)
+                    print(f"ADDED EDGE FROM {src} to {needed_snks}")
+            previous_ts = ts
+
+        if self.canonical:
+            self.canonical = False
+            self.canonicalize()
+
+    def _generate_candidate_sources(self, nodes):
+        sources = set()
+        for n in nodes:
+            for fi in n.fanin:
+                for src in fi.sources:
+                    if src.is_stateful():
+                        continue
+                    sources.add(src)
+        return sources
+
+    def _find_candidate_fwd(self, node, fwd_levels, bwd_levels, min_fwd_level, cache):
+        if node in cache:
+            return cache[node]
+
+        max_bwd_level = -1
+        best_candidate = None
+
+        # print(f"LOOKING FOR ANCHOR FOR SRC {node.name}")
+
+        for fo in node.fanout:
+            for snk in fo.sinks:
+                # print(
+                #    f"LOOKING AT SNK {snk.name} AT FWD {fwd_levels[snk]} BWD {bwd_levels[snk]}"
+                # )
+                if bwd_levels[snk] <= max_bwd_level:
+                    continue
+                if fwd_levels[snk] <= min_fwd_level:
+                    candidate, level = self._find_candidate_fwd(
+                        snk, fwd_levels, bwd_levels, min_fwd_level, cache
+                    )
+                    if level > max_bwd_level:
+                        max_bwd_level = level
+                        best_candidate = candidate
+                else:
+                    max_bwd_level = bwd_levels[snk]
+                    best_candidate = snk
+
+        cache[node] = (best_candidate, max_bwd_level)
+        return (best_candidate, max_bwd_level)
+
+    def _find_candidates_bwd(self, node):
+        candidates = set()
+        for fo in node.fanout:
+            for snk in fo.sinks:
+                for fi in snk.fanin:
+                    if fi is fo:
+                        continue
+                    if fi.is_stateful():
+                        continue
+                    candidates.update(fi.sources)
+
+        if len(candidates) == 0:
+            for fo in node.fanout:
+                for snk in fo.sinks:
+                    if snk.is_stateful():
+                        continue
+                    candidates.update(self._find_candidates_bwd(snk))
+
+        return candidates
+
+    # Build and return the line graph corresponding to this graph
+    # The line graph is always canonical
+    def build_line_graph(self):
+        assert self.canonical
+        line_graph = Graph()
+        for e in self.edges.values():
+            line_graph.add_node(e.name)
+        for n in self.nodes.values():
+            id = 0
+            if len(n.fanout) == 0:
+                continue
+            for fanin in n.fanin:
+                src = line_graph.nodes[fanin.name]
+                snks = []
+                for fanout in n.fanout:
+                    snks.append(line_graph.nodes[fanout.name])
+                line_graph.add_edge([src], snks, size=0, name=n.name + str(id))
+                id += 1
+
+        line_graph.canonicalize()
+        return line_graph
+
+    def build_dominator_tree(self, skip_allocations=True, skip_weights=True):
+        assert self.canonical
+        G = nx.DiGraph()
+        G.add_node("root")
+        for v in self.nodes:
+            G.add_node(v)
+        for e in self.edges.values():
+            src = e.source.name
+            for t in e.sinks:
+                G.add_edge(src, t.name)
+        for v in self.nodes.values():
+            if (
+                len(v.fanin) == 0
+                and (not skip_allocations or v.op_type != "allocate_tensor")
+                and (not skip_weights or v.op_type != "weight")
+            ):
+                G.add_edge("root", v.name)
+
+        return DominatorTree(
+            self, nx.algorithms.dominance.immediate_dominators(G, "root")
+        )
+
+    def _order_fanin_of_vertex_topologically(self, n, visited, ordering):
+        visited.add(n)
+        for fanin in n.fanin:
+            for src in fanin.sources:
+                if src in visited:
+                    continue
+                self._order_fanin_of_vertex_topologically(src, visited, ordering)
+        ordering.append(n)
+
+    def compute_topological_ordering(self):
+        visited = set()
+        ordering = []
+        for n in self.nodes.values():
+            if n.op_type == "stateful_node":
+                self._order_fanin_of_vertex_topologically(n, visited, ordering)
+        for n in self.nodes.values():
+            if n not in visited and not n.is_stateful():
+                self._order_fanin_of_vertex_topologically(n, visited, ordering)
+        for n in self.nodes.values():
+            if n.op_type == "stateful_node_sink":
+                self._order_fanin_of_vertex_topologically(n, visited, ordering)
+        return ordering
+
+    def build_levelization(self):
+        levelization = {}
+        for n in self.nodes.values():
+            if n in levelization:
+                continue
+            levelization[n] = self._compute_level(n, levelization)
+        return levelization
+
+    def _compute_level(self, node, levelization):
+        level = 0
+        for edge in node.fanin:
+            for src in edge.sources:
+                if src in levelization:
+                    lvl = levelization[src]
+                else:
+                    lvl = self._compute_level(src, levelization)
+                level = max(lvl + 1, level)
+        levelization[node] = level
+        return level
+
+    def build_reverse_levelization(self):
+        levelization = {}
+        for n in self.nodes.values():
+            if n in levelization:
+                continue
+            levelization[n] = self._compute_reverse_level(n, levelization)
+        return levelization
+
+    def _compute_reverse_level(self, node, levelization):
+        level = 0
+        for edge in node.fanout:
+            for sink in edge.sinks:
+                if sink in levelization:
+                    lvl = levelization[sink]
+                else:
+                    lvl = self._compute_reverse_level(sink, levelization)
+                level = max(lvl + 1, level)
+        levelization[node] = level
+        return level
+
+    def longest_path_length(self):
+        length = 0
+        for lvl in self.build_levelization().values():
+            length = max(length, lvl)
+        # Levels start at zero
+        return length + 1
+
+    # Returns true if the two edges are connected to the same node(s)
+    def are_connected_by_node(self, t1, t2):
+        nodes_connected_to_t1 = set(t1.sinks + [t1.source])
+        nodes_connected_to_t2 = set(t2.sinks + [t2.source])
+        return not nodes_connected_to_t1.isdisjoint(nodes_connected_to_t2)
+
+    # Return True iff t1 is in the immediate fanin of t2
+    def is_in_immediate_fanin(self, t1, t2):
+        assert self.canonical
+        for fanin in t2.fanin:
+            if fanin.source == t1:
+                return True
+        return False
+
+    # Return True iff t1 is in the transitive fanin of t2
+    @functools.lru_cache(maxsize=128 * 1024 * 1024)
+    def is_in_transitive_fanin(self, t1, t2, skip_intermediate_node=None):
+        # print(t1.name + " IN TRANSITIVE FANIN OF " + t2.name, flush=True)
+        for fanin in t2.fanin:
+            if fanin.source == skip_intermediate_node:
+                continue
+            # print("CHECKING FANIN " + fanin.source.name, flush=True)
+            if fanin.source == t1:
+                # print("1", flush=True)
+                return True
+            if self.is_in_transitive_fanin(t1, fanin.source):
+                # print("2", flush=True)
+                return True
+            # print("DONE WITH FANIN")
+        # print("3", flush=True)
+        return False
+
+    @functools.lru_cache(maxsize=256 * 1024 * 1024)
+    def is_t1_before_t2(self, t1, t2):
+        assert self.canonical
+        start2 = t2.source
+        for end1 in t1.sinks:
+            if not self.is_in_transitive_fanin(end1, start2):
+                return False
+
+        # print(t1.name + " comes before " + t2.name)
+        return True
+
+    def can_overlap_in_time(self, t1, t2):
+        if self.is_t1_before_t2(t1, t2):
+            return False
+        if self.is_t1_before_t2(t2, t1):
+            return False
+        return True
+
+    def sort(self):
+        self.nodes = dict(sorted(self.nodes.items()))
+        self.edges = dict(sorted(self.edges.items()))
+
+    def dump(self, filename=None, format="canon"):
+        large_graph = len(self.nodes) > 100 or len(self.edges) > 100
+        very_large_graph = len(self.nodes) > 250 or len(self.edges) > 250
+        if very_large_graph:
+            dot = Digraph(format=format, engine="neato")
+        else:
+            dot = Digraph(format=format)
+
+        if self.name:
+            dot.attr("graph", label=self.name)
+        dot.attr("node", shape="record")
+        # Speedup the layout of large graphs
+        if large_graph:
+            dot.attr("graph", overlap="scale")
+            dot.attr("graph", spline="line")
+
+        # Add the nodes
+        for node in self.nodes.values():
+            fanout_sz = len(node.fanout)
+            full_name = node.name
+            if not large_graph:
+                # Use extended label
+                if node.op_type:
+                    full_name += f" ({node.op_type})"
+                if node.size > 0 and node.time:
+                    full_name += f" [{node.size}, {node.time*1000:.2} ms]"
+                elif node.size > 0:
+                    full_name += f" [{node.size}]"
+                elif node.time:
+                    full_name += f" [{node.time*1000:.2} ms]"
+            if fanout_sz <= 1 or large_graph:
+                dot.node(node.name, label=full_name)
+            else:
+                # Small graph, use ports to distinguish edges
+                label = ""
+                for i in range(fanout_sz):
+                    label += "<f" + str(i) + "> " + full_name + "_" + str(i)
+                    if i < fanout_sz - 1:
+                        label += "|"
+                dot.node(node.name, label=label)
+
+        def edge_label(edge):
+            group_id = ""
+            if hasattr(edge, "group_id") and edge.group_id is not None:
+                group_id = f"g{edge.group_id}/"
+
+            return (
+                edge.name + "/" + group_id + str(edge.size) + "/" + str(edge.mem_space)
+                if edge.mem_space is not None
+                else str(edge.size)
+            )
+
+        # Add the edges
+        for node in self.nodes.values():
+            fanout_sz = len(node.fanout)
+            if fanout_sz == 0:
+                continue
+            elif fanout_sz == 1:
+                edge = node.fanout[0]
+                for sink in edge.sinks:
+                    dot.edge(node.name, sink.name, label=edge_label(edge))
+            else:
+                for i in range(fanout_sz):
+                    edge = node.fanout[i]
+                    for sink in edge.sinks:
+                        dot.edge(
+                            node.name if large_graph else node.name + ":f" + str(i),
+                            sink.name,
+                            label=edge_label(edge),
+                        )
+
+        if filename and format == "canon":
+            with open(filename, "w") as f:
+                for line in dot:
+                    f.write(line)
+                    if (not line.endswith("\n")):
+                        f.write("\n")
+            return filename
+        elif filename:
+            dot.render(filename=filename, format=format)
+            return filename
+        elif format == "canon":
+            result = ""
+            for line in dot:
+                result += line
+                if (not line.endswith("\n")):
+                    result += "\n"
+            return result
+        else:
+            return dot.pipe().decode("utf-8")
+
+    def check_duplicates(self):
+        """
+        Check whether graph has any duplicated sources/sinks.
+        """
+
+        for e in self.edges.values():
+            if isinstance(e, MultiSourceEdge):
+                seen_sources = set()
+                for source in e.sources:
+                    if source in seen_sources:
+                        raise AssertionError(
+                            f"MultiSourceEdge {e} has duplicate source"
+                        )
+                    seen_sources.add(source)
+
+            seen_sinks = set()
+            for snk in e.sinks:
+                if snk in seen_sinks:
+                    raise AssertionError(f"Edge {e} has duplicate sink")
+                seen_sinks.add(snk)
+
+        for n in self.nodes.values():
+            seen_fanout = set()
+            for e in n.fanout:
+                if e in seen_fanout:
+                    raise AssertionError(f"Node {n} has duplicate fanout")
+                seen_fanout.add(e)
+
+            seen_fanin = set()
+            for e in n.fanin:
+                if e in seen_fanin:
+                    raise AssertionError(f"Node {n} has duplicate fanin")
+                seen_fanin.add(e)
+
+    def check_for_self_edges(self):
+        """
+        Simple test to see whether graphs have any self edges (nodes which loop to themselves).
+        This won't detect longer cycles, however.
+        """
+
+        for e in self.edges.values():
+            for sink in e.sinks:
+                if (isinstance(e, MultiSourceEdge) and sink in e.sources) or (
+                    isinstance(e, Edge) and sink == e.source
+                ):
+                    raise AssertionError(f"node {sink} has self edge (edge {e})")
+
+    # Check the consistency of the graph
+    def check_consistency(self, verbose=False):
+        for e in self.edges.values():
+            for source in e.sources:
+                if e not in source.fanout:
+                    if verbose:
+                        print(
+                            f"Edge {e.name} not in fanout of {source.name}", flush=True
+                        )
+                    return False
+
+            for snk in e.sinks:
+                if e not in snk.fanin:
+                    if verbose:
+                        print(f"Edge {e.name} not in fanin of {snk.name}", flush=True)
+                    return False
+
+        for n in self.nodes.values():
+            for e in n.fanout:
+                if isinstance(e, MultiSourceEdge):
+                    if n not in e.sources:
+                        if verbose:
+                            print(
+                                f"{n.name} not in sources of edge {e.name}", flush=True
+                            )
+                        return False
+                else:
+                    if e.source != n:
+                        if verbose:
+                            print(
+                                f"{n.name} not the source of edge {e.name}", flush=True
+                            )
+                        return False
+
+            for e in n.fanin:
+                if n not in e.sinks:
+                    if verbose:
+                        print(f"{n.name} not in sinks of edge {e.name}", flush=True)
+                    return False
+
+        self.check_duplicates()
+        self.check_for_self_edges()
+
+        return True
+
+    def _has_loop_in_fanout(self, node, status, verbose):
+        if node in status:
+            return status[node] != 2
+
+        status[node] = 1
+        for e in node.fanout:
+            for s in e.sinks:
+                has_loop = self._has_loop_in_fanout(s, status, verbose)
+                if has_loop:
+                    if verbose:
+                        print(f"Found loop through node {s.name}", flush=True)
+                    return True
+        status[node] = 2
+        return False
+
+    def has_loops(self, verbose=False):
+        status = {}
+        for n in self.nodes.values():
+            if self._has_loop_in_fanout(n, status, verbose):
+                return True
+        return False
+
+    def is_valid(self, verbose=False):
+        try:
+            valid = self.check_consistency(verbose)
+        except Exception:
+            return False
+
+        valid &= not self.has_loops(verbose)
+        return valid
+
+    # count all the sink connections in all edges
+    def sink_count(self):
+        sinks = 0
+        for e in self.edges.values():
+            sinks += len(e.sinks)
+
+        return sinks
+
+    # count all the source connections in all edges
+    def source_count(self):
+        sources = 0
+        for e in self.edges.values():
+            if isinstance(e, MultiSourceEdge):
+                sources += len(e.sources)
+            else:
+                sources += 1
+
+        return sources
+
+    # usually the size of a tensor is at the edge, but for weight nodes, it could be at the node
+    def get_size(self, edge):
+        if edge.size != 0:
+            return edge.size
+        else:
+            if isinstance(edge, MultiSourceEdge):
+                size = 0
+                for source in edge.sources:
+                    size += source.size
+                return size
+            else:
+                return edge.source.size
+
+    def __repr__(self):
+        result = ""
+        for v in self.nodes.values():
+            result += str(v) + "\n"
+        result += "\n"
+        for e in self.edges.values():
+            result += str(e) + "\n"
+        return result
+
+
+# Partial schedule for the nodes of a Graph
+class ScheduleConstraints:
+    def __init__(self, graph, constraints):
+        self.graph = graph
+        self.node_schedule = dict()
+        for node, ts in constraints.items():
+            if isinstance(node, str):
+                # some nodes get pruned in importer
+                if node in graph.nodes:
+                    n = graph.nodes[node]
+                    self.node_schedule[n] = ts
+            else:
+                assert isinstance(node, Node)
+                self.node_schedule[node] = ts
+
+    def __iter__(self):
+        return self.node_schedule.__iter__()
+
+    def find(self, node):
+        assert isinstance(node, Node)
+        return self.node_schedule.get(node)
+
+    def items(self):
+        return self.node_schedule.items()
+
+    # Reduce the gap between the timesteps in the schedule. This
+    # speeds up the computation
+    # This must be called before calling fixup()
+    def compress(self):
+        # Python hashtables preserve insertion order
+        sorted_schedule = {
+            k: v
+            for k, v in sorted(self.node_schedule.items(), key=lambda item: item[1])
+        }
+        index = 1
+        for k, v in sorted_schedule.items():
+            if index < v:
+                sorted_schedule[k] = index
+            index += 2
+        self.node_schedule = sorted_schedule
+
+    # Fix the user specified schedule: handle unspecified execution times for
+    # memory allocation nodes.
+    def fixup(self):
+        for node in self.graph.nodes.values():
+            if node.op_type != "allocate_tensor" or node in self.node_schedule:
+                continue
+            # No user specified schedule for an allocation node: schedule the allocation
+            # as late as possible
+            print("Found unscheduled allocation node " + node.name)
+            alap = 10000000
+            for e in node.fanout:
+                for fanout in e.sinks:
+                    if fanout not in self.node_schedule:
+                        print("fanout " + fanout.name + " has unspecified schedule")
+                        alap = -1
+                        break
+                    else:
+                        alap = min(alap, self.node_schedule[fanout] - 1)
+            if alap >= 0 and alap < 10000000:
+                print("Schedules node " + node.name + " at ts = " + str(alap))
+                self.node_schedule[node] = alap
+
+
+class DominatorTree:
+    def __init__(self, graph, immediate_dominators):
+        self.dominators = defaultdict(lambda: None)
+        for v, d in immediate_dominators.items():
+            # print(v + " dominated by " + d)
+            # assert v != "root"
+            if v == "root" or d == "root":
+                continue
+            node = graph.nodes[v]
+            idom = graph.nodes[d]
+            self.dominators[node] = idom
+
+    def lowest_common_ancestor(self, nodes):
+        if len(nodes) == 1:
+            return self.dominators[nodes[0]]
+        common_ancestors = set()
+        d = self.dominators[nodes[0]]
+        while d is not None:
+            common_ancestors.add(d)
+            d = self.dominators[d]
+
+        for n in nodes[1:]:
+            ancestors = set()
+            d = self.dominators[n]
+            while d is not None:
+                ancestors.add(d)
+                d = self.dominators[d]
+            common_ancestors = common_ancestors.intersection(ancestors)
+
+        d = self.dominators[nodes[0]]
+        while d is not None and d not in common_ancestors:
+            d = self.dominators[d]
+
+        return d
+
+    def __str__(self):
+        result = ""
+        for n, d in self.dominators.items():
+            result += n.name + " dominated by " + d.name + "\n"
+        return result

--- a/olla/defragmenter.py
+++ b/olla/defragmenter.py
@@ -1,0 +1,65 @@
+from collections import OrderedDict
+
+from olla import ilp_solver
+
+
+# Optimize a memory layout to limit fragmentation.
+class Defragmenter:
+    # Given a set of tensors which are alive in the timerange [s, e], figure
+    # out the base address of each tensor that minimizes the peak total memory
+    # usage. The span argument is expected to be a dictionary of tuples indexed
+    # by tensors, i.e. dataflow_graph.Edge {tensor: (start_time, end_time)}
+    # Returns a map of {tensor: base address}
+    def ComputeBestLayout(self, spans):
+        solver = ilp_solver.ILPSolver()
+
+        # Track the maximum address that can be used
+        max_address = solver.create_integer_var("max_address", lower_bound=0)
+
+        total_size = 0
+        # Create a new variable for each tensor that tracks the base address
+        # of the tensor
+        variables = OrderedDict()
+        for tensor in spans.keys():
+            v = solver.create_integer_var(tensor.name, lower_bound=0)
+            variables[tensor] = v
+            solver.add_constraint(v + tensor.size <= max_address)
+            total_size += tensor.size
+
+        solver.add_constraint(max_address <= total_size)
+
+        processed = set()
+        for t1, span1 in spans.items():
+            # Help the solver by providing upper bounds for all the addresses
+            solver.add_constraint(variables[t1] + t1.size <= total_size)
+            for t2, span2 in spans.items():
+                if t1 is t2:
+                    continue
+                if (t2, t1) in processed:
+                    continue
+                processed.add((t1, t2))
+                if span1[1] >= span2[0] and span1[0] <= span2[1]:
+                    # The spans overlap: one of these 2 constraints must hold:
+                    # variables[t1] + t1.size <= variables[t2]
+                    # variables[t1] >= variables[t2] + t2.size
+                    v1 = solver.create_binary_var(t1.name + "_" + t2.name + "_v1")
+                    solver.add_constraint(
+                        variables[t1] + t1.size - variables[t2] <= (1 - v1) * total_size
+                    )
+                    v2 = solver.create_binary_var(t1.name + "_" + t2.name + "_v2")
+                    solver.add_constraint(
+                        variables[t1] - variables[t2] - t2.size >= (v2 - 1) * total_size
+                    )
+                    solver.add_constraint(v1 + v2 >= 1)
+                    solver.add_constraint(2 - v1 - v2 >= 1)
+
+        solver.set_objective_function(max_address, maximize=False)
+
+        result = solver.solve()
+
+        # Return a map of {tensor: base address}
+        base_addresses = {}
+        for tensor in spans.keys():
+            base_addresses[tensor] = result[variables[tensor]]
+
+        return base_addresses

--- a/olla/ilp_solver.py
+++ b/olla/ilp_solver.py
@@ -1,0 +1,210 @@
+import sys
+import logging
+from typing import Any, Callable, Dict, List, Optional, Union
+from dataclasses import dataclass
+
+import gurobipy as gr
+
+logger = logging.getLogger(__name__)
+
+# Wrap is the xpress solver (https://pypi.org/project/xpress/, doc available at
+# https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/python/HTML/GUID-616C323F-05D8-3460-B0D7-80F77DA7D046.html)
+# to ensure that we can easily try other solvers in the future if needs be.
+class ILPSolver:
+    # A negative timeout is a hard timeout, in which case the solver returns within the specified amount of time whether or not it found a solution
+    # A positive timeout is soft: the solver can exceed the timeout in order to find one feasible solution.
+    # Valid solvers are "xpress" and "gurobi"
+    def __init__(
+        self,
+        timeout_s=None,
+        rel_stop=None,
+        solver="gurobi",
+        method=None,
+        int_feas_tol=None,
+        extra_params=None,
+    ):
+        self.vars = []
+        self.timeout = timeout_s
+        self.rel_stop = rel_stop
+        self.method = method
+        self.int_feas_tol = int_feas_tol
+        self.extra_params = extra_params
+        self.num_constraints = 0
+        if solver == "GUROBI" or solver == "gurobi":
+            self.model = gr.Model("gurobi")
+        else:
+            raise Exception("Currently only Gurobi solver is supported.")
+        self._message_callback = None
+
+        self.binary = gr.GRB.BINARY
+        self.integer = gr.GRB.INTEGER
+        self.continuous = gr.GRB.CONTINUOUS
+        self.semicontinuous = gr.GRB.SEMICONT
+        self.semiinteger = gr.GRB.SEMIINT
+        self.minimize = gr.GRB.MINIMIZE
+        self.maximize = gr.GRB.MAXIMIZE
+
+        self.mip_optimal = gr.GRB.OPTIMAL
+        self.mip_solution = gr.GRB.SUBOPTIMAL
+        self.mip_infeas = gr.GRB.INFEASIBLE
+        self.mip_unbounded = gr.GRB.UNBOUNDED
+        self.mip_no_sol_found = gr.GRB.TIME_LIMIT
+        self.mip_lp_not_optimal = gr.GRB.LOADED
+        self.lp_optimal = gr.GRB.OPTIMAL
+        self.lp_infeas = gr.GRB.INFEASIBLE
+        self.lp_unbounded = gr.GRB.UNBOUNDED
+
+        @dataclass
+        class GurobiAttributes:
+            bestbound = None
+            mipstatus = gr.GRB.LOADED
+        self.attributes = GurobiAttributes()
+
+
+
+    def create_integer_var(self, name, lower_bound=None, upper_bound=None):
+        assert name is not None
+        if type(name) != str:
+            name = str(name)
+        lb = -sys.maxsize if lower_bound is None else lower_bound
+        ub = sys.maxsize if upper_bound is None else upper_bound
+        v = self.model.addVar(
+            name=name, lb=lb, ub=ub, vtype=self.integer
+        )
+        self.vars.append(v)
+        return v
+
+    def create_real_var(self, name, lower_bound=None, upper_bound=None):
+        assert name is not None
+        if type(name) != str:
+            name = str(name)
+        lb = -float("inf") if lower_bound is None else lower_bound
+        ub = float("inf") if upper_bound is None else upper_bound
+        v = self.model.addVar(
+            name=name, lb=lb, ub=ub, vtype=self.continuous
+        )
+        self.vars.append(v)
+        return v
+
+    def create_binary_var(self, name):
+        assert name is not None
+        if type(name) != str:
+            name = str(name)
+        v = self.model.addVar(name=name, vtype=self.binary)
+        self.vars.append(v)
+        return v
+
+    def set_objective_function(self, equation, maximize=True):
+        self.of = equation
+        if maximize:
+            self.model.setObjective(equation, sense=self.maximize)
+        else:
+            self.model.setObjective(equation, sense=self.minimize)
+
+    def add_constraint(self, cns, name=""):
+        self.num_constraints += 1
+        # Make sure names aren't too long for gurobi
+        if len(name) >= 250:
+            # old_name = name
+            num_cns = str(self.num_constraints)
+            name = name[: 250 - len(num_cns)] + num_cns
+            # print(
+            #    f"truncated contraint name from {old_name} to {name}"
+            # )
+        self.model.addLConstr(cns, name=name)
+
+    def solve(self):
+        # Solve the problem. Return the result as a dictionary of values
+        # indexed by the corresponding variables or an empty dictionary if the
+        # problem is infeasible.
+        if self.timeout:
+            timeout = float("inf") if self.timeout == 0 else abs(self.timeout)
+            self.model.setParam("maxtime", timeout)
+        if self.rel_stop:
+            self.model.setParam("miprelstop", self.rel_stop)
+        if self.method:
+            self.model.setParam("Method", self.method)
+        if self.int_feas_tol:
+            self.model.setParam("IntFeasTol", self.int_feas_tol)
+        if self.extra_params:
+            for param, value in self.extra_params.items():
+                self.model.setParam(param, value)
+
+        self.model.optimize(self._message_callback)
+        logger.debug(f"Gurobi problem status {self.model.Status}")
+        logger.debug("Extracting results...")
+        if self.model.Status == gr.GRB.OPTIMAL:
+            self.gurobi_recorded_solution = self._get_var_name_map_value()
+        if self.model.IsMIP:
+            self.attributes.bestbound = self.model.ObjBound
+            self.attributes.mipstatus = self.getProbStatus()
+
+        if self.getProbStatus() == self.mip_infeas:
+            self.model.computeIIS()
+            violations = ""
+            for c in self.model.getConstrs():
+                if c.IISConstr:
+                    violations += "\n" + str(c)
+
+            raise RuntimeError(
+                "Problem is not feasible as the following constraint(s) cannot be satisfied: "
+                + violations
+            )
+        elif (
+            # mip_no_sol_found actually means timeout !
+            self.getProbStatus() != self.mip_no_sol_found
+            and self.getProbStatus() != self.mip_optimal
+            and self.getProbStatus() != self.mip_solution
+        ):
+            raise RuntimeError("Unknown error detected while solving ilp")
+
+        if self.model.SolCount == 0:
+            raise RuntimeError("No solution found")
+
+        result = {}
+        for v in self.vars:
+            result[v] = v.X
+        return result
+
+    def solve_relaxation(self):
+        self.model.update()
+        relaxed_model = self.model.relax()
+        relaxed_model.optimize()
+        result = {}
+        for v in relaxed_model.getVars():
+            # Need to index the result by variable name since the relaxed model
+            # will be released as soon as we exit the method
+            result[v.varName] = v.X
+        return result
+
+    def getProbStatus(self) -> Any:
+        return self.model.Status
+
+    def _get_var_name_map_value(self) -> Dict[str, Any]:
+        name_map_value = {}
+        for v in self.model.getVars():
+            name_map_value[v.varName] = v.getAttr(gr.GRB.Attr.X)
+        return name_map_value
+
+    def write(self, filename: Any, filetype: str = "lp") -> None:
+
+        if filetype:
+            filename += "." + filetype
+        else:
+            if not (
+                ".mps" in filename
+                or ".rew" in filename
+                or ".lp" in filename
+                or ".rlp" in filename
+            ):
+                filename += ".lp"
+                logger.debug(f"filename updated {filename}")
+        # Added for debugging
+        # self.model.computeIIS()
+        # self.model.write("model.ilp")
+
+        self.model.write(filename)
+
+    def __str__(self):
+        result = "Num Variables = " + str(len(self.vars))
+        return result

--- a/olla/max_cut.py
+++ b/olla/max_cut.py
@@ -1,0 +1,195 @@
+from olla import ilp_solver
+
+
+class MaxCut:
+    # If weighted is True, each edge is weigthed by its size, otherwise each
+    # edge is assigned the weight of one.
+    # The weighted max cut will give us the peak memory usage, while the
+    # unweighted max cut will give us the maximum number of tensors that can be
+    # live at the same time.
+    def __init__(
+        self,
+        graph,
+        weighted=True,
+        skip_weights=True,
+        debug=False,
+        rel_stop=None,
+    ):
+        assert graph.canonical
+
+        self.graph = graph
+        self.weighted = weighted
+        self.skip_weights = skip_weights
+        self.debug = debug
+        self.rel_stop = rel_stop
+
+    def LocateCut(self, user_schedule=None):
+        # Partition the graph in 2 subgraphs S and T. For each node in a the
+        # corresponding boolean variable will take value 1, while the variable
+        # will take value 0 for the nodes in T
+        # Also create a variable for each edge, that will take value 1 for the
+        # edges alongside the cut between S and T and o for all the other edges.
+        solver = ilp_solver.ILPSolver(solver="GUROBI", rel_stop=self.rel_stop)
+
+        # Create a new variable for each node
+        node_vars = {}
+        for n in self.graph.nodes.values():
+            if self.skip_weights and n.is_stateful():
+                continue
+            v = solver.create_binary_var(n.name)
+            node_vars[n] = v
+            # Help the search by forcing the value of the graph inputs and outputs
+            if len(n.fanin) == 0:
+                solver.add_constraint(v == 1)
+            elif len(n.fanout) == 0:
+                solver.add_constraint(v == 0)
+
+        # Create a new variable for each edge and add constraints
+        edge_vars = {}
+        for e in self.graph.edges.values():
+            if self.skip_weights and e.is_stateful():
+                continue
+            src = node_vars[e.source]
+
+            if e.size == 0:
+                for s in e.sinks:
+                    snk = node_vars[s]
+                    # Add precedence constraints
+                    solver.add_constraint(src >= snk)
+                continue
+
+            v = solver.create_binary_var("e_" + str(e.name))
+            edge_vars[e] = v
+            sum_snks = 0
+            for s in e.sinks:
+                snk = node_vars[s]
+                sum_snks += snk
+                # Add precedence constraints
+                solver.add_constraint(src >= snk)
+                # If the source and at least one sink are on different
+                # partitions, then the edge is on the max cut.
+                solver.add_constraint(v >= src - snk)
+
+            # If the source and all the sinks are in partition zero, then the
+            # edge is not on the max cut
+            solver.add_constraint(v <= src + sum_snks)
+
+            # If the source and all the sinks are in partition one, then the
+            # edge is not on the max cut
+            solver.add_constraint(v <= 1 + len(e.sinks) - src - sum_snks)
+
+        # Add constraints coming from user schedule
+        if user_schedule:
+            ordered = []
+            for node, order in user_schedule.items():
+                ordered.append((order, node))
+            ordered.sort()
+            for i in range(1, len(ordered)):
+                src = ordered[i - 1][1]
+                snk = ordered[1][1]
+                print(f"Adding edge from {src.name} to {snk.name}")
+                solver.add_constraint(node_vars[src] >= node_vars[snk])
+
+        # The max cut size is the sum of all the sizes of the edges on the cut
+        max_cut_size = 0
+        for e, v in edge_vars.items():
+            if e.size == 0:
+                continue
+            cut_size = e.size if self.weighted else 1
+            max_cut_size += v * cut_size
+
+        # To get the total memory usage, we need to add the size of all the
+        # tensors t in the immediate fanin of the max cut since these tensors
+        # remain in memory while the corresponding ops are run.
+        fanout_on_cut = {}
+        for e in edge_vars.keys():
+            if e.size == 0 or len(e.sinks) == 0:
+                continue
+            d = solver.create_binary_var("is_fanout_of_" + e.name + "_on_max_cut")
+            fanout_on_cut[e] = d
+            edge_size = e.size if self.weighted else 1
+            max_cut_size += d * edge_size
+            active_fanouts = 0
+            for edge_sinks in e.sinks:
+                for snk in edge_sinks.fanout:
+                    if snk.size == 0:
+                        continue
+                    if self.skip_weights and snk.is_stateful():
+                        continue
+                    is_e_on_max_cut = edge_vars[snk]
+                    active_fanouts += is_e_on_max_cut
+                    solver.add_constraint(d >= is_e_on_max_cut)
+
+            solver.add_constraint(d <= active_fanouts)
+
+        solver.set_objective_function(max_cut_size)
+
+        max_cut = []
+        live_tensors = set()
+        result = solver.solve()
+        for e, v in edge_vars.items():
+            if result[v] >= 0.99:
+                max_cut.append(e.source)
+                live_tensors.add(e)
+                for t in e.source.fanin:
+                    live_tensors.add(t)
+
+        cut_size = 0
+        for t in live_tensors:
+            if t.size == 0:
+                continue
+            cut_size += t.size if self.weighted else 1
+
+        if self.debug:
+            print(str(result))
+
+            for e in self.graph.edges.values():
+                if self.skip_weights and e.is_stateful():
+                    continue
+                if e.size == 0:
+                    continue
+
+                if result[edge_vars[e]] >= 0.99:
+                    assert e in live_tensors
+                    assert result[node_vars[e.source]] >= 0.99
+                    found_snk = False
+                    for snk in e.sinks:
+                        if result[node_vars[snk]] <= 0.01:
+                            found_snk = True
+                            break
+                    if not found_snk:
+                        print(f"Invalid edge {e.name}")
+                        print(f"  SRC {e.source.name} = {result[node_vars[e.source]]}")
+                        for snk in e.sinks:
+                            print(f"  SNK {snk.name} = {result[node_vars[snk]]}")
+                    assert found_snk
+
+                else:
+                    for snk in e.sinks:
+                        if result[node_vars[snk]] <= 0.5:
+                            assert result[node_vars[e.source]] <= 0.5
+                        if result[node_vars[snk]] > 0.5:
+                            assert result[node_vars[e.source]] > 0.5
+
+            max_cut_size = 0
+            for e, v in edge_vars.items():
+                if e.size == 0:
+                    continue
+                edge_size = e.size if self.weighted else 1
+                if result[v] >= 0.99:
+                    print(f"Edge {e.name} adds {edge_size} to the max cut")
+                    max_cut_size += edge_size
+
+            for e in edge_vars.keys():
+                if e.size == 0 or len(e.sinks) == 0:
+                    continue
+                edge_size = e.size if self.weighted else 1
+                if result[fanout_on_cut[e]]:
+                    print(
+                        f"Edge {e.name} adds {edge_size} to the max cut since its fanout is on maxcut"
+                    )
+                    max_cut_size += edge_size
+
+            print(f"Max cut size is {max_cut_size}")
+
+        return (cut_size, max_cut)

--- a/olla/memory_planner.py
+++ b/olla/memory_planner.py
@@ -1,0 +1,45 @@
+import copy
+
+from olla import dataflow_graph, scheduler, utils
+
+
+class MemoryPlanner:
+    def __init__(self, timeout_s=None, rel_stop=None, optimize=False):
+        self.timeout = timeout_s
+        self.rel_stop = rel_stop
+        self.optimize = optimize
+
+    def plan(self, graph, mem_limit, user_schedule=None):
+        optimized_graph = copy.deepcopy(graph)
+        if self.optimize:
+            if user_schedule is None:
+                optimized_graph.prune(aggressive=True)
+                optimized_graph.canonicalize()
+                optimized_graph.constrain_allocations()
+                optimized_graph.constrain_weights()
+            else:
+                optimized_graph.canonicalize()
+                user_schedule = dataflow_graph.ScheduleConstraints(graph, user_schedule)
+                user_schedule.fixup()
+        else:
+            optimized_graph.canonicalize()
+        assert optimized_graph.check_consistency()
+
+        solver = scheduler.Scheduler(optimized_graph)
+        summary, schedule, mem_loc = solver.ComputeOptimalSchedule(
+            mem_limit=mem_limit,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+        )
+        assert utils.validate_address_allocation(mem_loc)
+        assert utils.validate_timeline(schedule)
+
+        # TBD parse result
+        # The driver of each tensor is allocated at the time the corresponding op must run
+        # The few tricks are:
+        #  also schedule the nodes that were pruned
+        #  insert malloc/free nodes. For malloc it's going to be the allocate nodes if any, or the edge driver
+        # for free it's going to be right after the last use of a tensor.
+        #  insert spill-out/spill-in nodes. For spill-in the schedule tells us when, for spill out we'll have to figure this out.
+        return summary

--- a/olla/native_graphs/control_dep_graph.py
+++ b/olla/native_graphs/control_dep_graph.py
@@ -1,0 +1,22 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="A")
+B = graph.add_node(name="B")
+C = graph.add_node(name="C")
+D = graph.add_node(name="D")
+E = graph.add_node(name="E")
+F = graph.add_node(name="F")
+G = graph.add_node(name="G")
+
+graph.add_edge([A], [B], size=10)
+graph.add_edge([B], [C], size=20)
+graph.add_edge([B], [D], size=30)
+graph.add_edge([D], [E], size=40)
+graph.add_edge([E], [F], size=50)
+graph.add_edge([C], [F], size=60)
+graph.add_edge([F], [G], size=10)
+graph.add_edge([C], [E], size=0)
+
+graph.canonicalize()

--- a/olla/native_graphs/diamond_graph.py
+++ b/olla/native_graphs/diamond_graph.py
@@ -1,0 +1,21 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="A")
+B = graph.add_node(name="B")
+C = graph.add_node(name="C")
+D = graph.add_node(name="D")
+E = graph.add_node(name="E")
+F = graph.add_node(name="F")
+G = graph.add_node(name="G")
+
+graph.add_edge([A], [B], size=10)
+graph.add_edge([B], [C], size=20)
+graph.add_edge([B], [D], size=30)
+graph.add_edge([D], [E], size=40)
+graph.add_edge([E], [F], size=50)
+graph.add_edge([C], [F], size=60)
+graph.add_edge([F], [G], size=10)
+
+graph.canonicalize()

--- a/olla/native_graphs/diamond_graph_with_weight.py
+++ b/olla/native_graphs/diamond_graph_with_weight.py
@@ -1,0 +1,28 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="A")
+B = graph.add_node(name="B")
+C = graph.add_node(name="C")
+D = graph.add_node(name="D")
+E = graph.add_node(name="E")
+F = graph.add_node(name="F")
+G = graph.add_node(name="G")
+H = graph.add_node(name="H")
+I = graph.add_node(name="I")
+W = graph.add_node(name="W", size=123)
+
+graph.add_edge([A], [B], size=10)
+graph.add_edge([B], [C], size=20)
+graph.add_edge([B], [D], size=30)
+graph.add_edge([D], [E], size=40)
+graph.add_edge([C], [E], size=50)
+graph.add_edge([E], [F], size=60)
+graph.add_edge([E], [G], size=70)
+graph.add_edge([F], [H], size=80)
+graph.add_edge([G], [H], size=90)
+graph.add_edge([H], [I], size=100)
+graph.add_edge([W], [I], size=0)
+
+graph.canonicalize()

--- a/olla/native_graphs/graph_with_bmmadd.py
+++ b/olla/native_graphs/graph_with_bmmadd.py
@@ -1,0 +1,32 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+IN = graph.add_node(name="INPUT")
+IN2 = graph.add_node(name="INPUT2")
+W = graph.add_node(name="WEIGHT", size=123)
+B = graph.add_node(name="BIAS", size=321)
+T = graph.add_node(name="TRANSPOSE")
+O1 = graph.add_node(name="OPERATOR1")
+O2 = graph.add_node(name="OPERATOR2")
+O3 = graph.add_node(name="OPERATOR3")
+O4 = graph.add_node(name="OPERATOR4")
+O5 = graph.add_node(name="OPERATOR5")
+O6 = graph.add_node(name="OPERATOR6")
+BMMADD = graph.add_node(name="BMMADD")
+OUT = graph.add_node(name="OUTPUT")
+
+graph.add_edge([B], [T], size=10, name="TRANSPOSE")
+graph.add_edge([IN], [O1], size=20, name="ACTIVATION1")
+graph.add_edge([O1], [O2], size=30, name="ACTIVATION2")
+graph.add_edge([O2], [O3], size=40, name="ACTIVATION3")
+graph.add_edge([O3], [BMMADD], size=50, name="ACTIVATION4")
+graph.add_edge([T], [BMMADD], size=60, name="WEIGHT_TRANSPOSED")
+graph.add_edge([W], [BMMADD], size=70, name="WEIGHT_REF1")
+graph.add_edge([BMMADD], [O4], size=80, name="ACTIVATION5")
+graph.add_edge([O4], [O5], size=90, name="ACTIVATION6")
+graph.add_edge([O5], [OUT], size=100, name="OUTPUT_EDGE")
+graph.add_edge([IN2], [O6], size=110, name="ACTIVATION7")
+graph.add_edge([O6], [O2], size=120, name="ACTIVATION8")
+
+graph.canonicalize()

--- a/olla/native_graphs/graph_with_constants.py
+++ b/olla/native_graphs/graph_with_constants.py
@@ -1,0 +1,16 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="INPUT")
+B = graph.add_node(name="CONSTANT", size=3, read_only=True)
+C = graph.add_node(name="OPERATOR")
+D = graph.add_node(name="OUTPUT")
+
+graph.add_edge([A], [C], size=10, name="ACTIVATION_EDGE")
+graph.add_edge(
+    [B], [C], size=3 * 10, name="CONSTANT_EDGE"
+)  # We assume there's some broadcasting going on
+graph.add_edge([C], [D], size=50, name="OUTPUT_EDGE")
+
+graph.canonicalize()

--- a/olla/native_graphs/graph_with_gradients.py
+++ b/olla/native_graphs/graph_with_gradients.py
@@ -1,0 +1,34 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+IN = graph.add_node(name="INPUT")
+W1 = graph.add_node(name="WEIGHT1", size=123)
+W2 = graph.add_node(name="WEIGHT2", size=321)
+O1 = graph.add_node(name="OPERATOR1")
+O2 = graph.add_node(name="OPERATOR2")
+OUT = graph.add_node(name="OUTPUT")
+
+L = graph.add_node(name="LOSS")
+G1 = graph.add_node(name="GRADIENT1")
+G2 = graph.add_node(name="GRADIENT2")
+G3 = graph.add_node(name="GRADIENT3")
+GW1 = graph.add_node(name="GRADIENT_W1")
+GW2 = graph.add_node(name="GRADIENT_W2")
+
+AG1 = graph.add_node(name="APPLY_GRADIENT_W1")
+AG2 = graph.add_node(name="APPLY_GRADIENT_W2")
+
+graph.add_edge([IN], [O1, GW1], size=10, name="ACTIVATION1")
+graph.add_edge([W1], [O1, G1, AG1], size=0, name="WEIGHT_REF1")
+graph.add_edge([O1], [O2, GW2], size=30, name="ACTIVATION2")
+graph.add_edge([W2], [O2, G2, AG2], size=0, name="WEIGHT_REF2")
+graph.add_edge([O2], [OUT], size=50, name="OUTPUT_EDGE")
+
+graph.add_edge([G3], [G2, GW2], size=345, name="PROPAGATE_G1")
+graph.add_edge([G2], [G1, GW1], size=543, name="PROPAGATE_G2")
+
+graph.add_edge([GW1], [AG1], size=567, name="UPDATE_W1")
+graph.add_edge([GW2], [AG2], size=765, name="UPDATE_W2")
+
+graph.canonicalize()

--- a/olla/native_graphs/graph_with_two_weights.py
+++ b/olla/native_graphs/graph_with_two_weights.py
@@ -1,0 +1,18 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+IN = graph.add_node(name="INPUT")
+W1 = graph.add_node(name="WEIGHT1", size=123)
+W2 = graph.add_node(name="WEIGHT2", size=321)
+O1 = graph.add_node(name="OPERATOR1")
+O2 = graph.add_node(name="OPERATOR2")
+OUT = graph.add_node(name="OUTPUT")
+
+graph.add_edge([IN], [O1], size=10, name="ACTIVATION1")
+graph.add_edge([W1], [O1], size=0, name="WEIGHT_REF1")
+graph.add_edge([O1], [O2], size=30, name="ACTIVATION2")
+graph.add_edge([W2], [O2], size=0, name="WEIGHT_REF2")
+graph.add_edge([O2], [OUT], size=50, name="OUTPUT_EDGE")
+
+graph.canonicalize()

--- a/olla/native_graphs/graph_with_weights.py
+++ b/olla/native_graphs/graph_with_weights.py
@@ -1,0 +1,16 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="INPUT")
+B = graph.add_node(name="WEIGHT", size=123)
+C = graph.add_node(name="OPERATOR")
+D = graph.add_node(name="OUTPUT")
+
+graph.add_edge([A], [C], size=10, name="ACTIVATION_EDGE")
+graph.add_edge(
+    [B], [C], size=0, name="WEIGHT_EDGE"
+)  # It's just a reference to the data stored in the weight node
+graph.add_edge([C], [D], size=50, name="OUTPUT_EDGE")
+
+graph.canonicalize()

--- a/olla/native_graphs/multi_fanin_output_graph.py
+++ b/olla/native_graphs/multi_fanin_output_graph.py
@@ -1,0 +1,17 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="A")
+B = graph.add_node(name="B")
+C = graph.add_node(name="C")
+D = graph.add_node(name="D")
+E = graph.add_node(name="E")
+
+graph.add_edge([A], [B], size=10)
+graph.add_edge([A], [C], size=20)
+graph.add_edge([B], [D], size=30)
+graph.add_edge([D], [E], size=40)
+graph.add_edge([C], [E], size=50)
+
+graph.canonicalize()

--- a/olla/native_graphs/pathological_graph.py
+++ b/olla/native_graphs/pathological_graph.py
@@ -1,0 +1,32 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+M0 = graph.add_node(name="M0")
+M1 = graph.add_node(name="M1")
+M2 = graph.add_node(name="M2")
+M3 = graph.add_node(name="M3")
+M4 = graph.add_node(name="M4")
+M5 = graph.add_node(name="M5")
+M6 = graph.add_node(name="M6")
+M7 = graph.add_node(name="M7")
+
+F0 = graph.add_node(name="F0")
+F1 = graph.add_node(name="F1")
+F2 = graph.add_node(name="F2")
+F3 = graph.add_node(name="F3")
+F4 = graph.add_node(name="F4")
+F5 = graph.add_node(name="F5")
+F6 = graph.add_node(name="F6")
+F7 = graph.add_node(name="F7")
+
+graph.add_edge([M0], [F0], size=1, name="T0")
+graph.add_edge([M1], [F1], size=9, name="T1")
+graph.add_edge([M2], [F2], size=1, name="T2")
+graph.add_edge([M3], [F3], size=8, name="T3")
+graph.add_edge([M4], [F4], size=1, name="T4")
+graph.add_edge([M5], [F5], size=7, name="T5")
+graph.add_edge([M6], [F6], size=8, name="T6")
+graph.add_edge([M7], [F7], size=7, name="T7")
+
+graph.canonicalize()

--- a/olla/native_graphs/shared_multi_fanin_output_graph.py
+++ b/olla/native_graphs/shared_multi_fanin_output_graph.py
@@ -1,0 +1,14 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="A")
+B = graph.add_node(name="B")
+C = graph.add_node(name="C")
+D = graph.add_node(name="D")
+
+graph.add_edge([A], [B], size=10)
+graph.add_edge([A], [C], size=20)
+graph.add_edge([B, C], [D], size=30)
+
+graph.canonicalize()

--- a/olla/native_graphs/simple_graph.py
+++ b/olla/native_graphs/simple_graph.py
@@ -1,0 +1,16 @@
+from olla import dataflow_graph
+
+graph = dataflow_graph.Graph()
+
+A = graph.add_node(name="A")
+B = graph.add_node(name="B")
+C = graph.add_node(name="C")
+D = graph.add_node(name="D")
+E = graph.add_node(name="E")
+
+graph.add_edge([A], [B], size=10)
+graph.add_edge([B], [C], size=20)
+graph.add_edge([B], [D], size=30)
+graph.add_edge([D], [E], size=40)
+
+graph.canonicalize()

--- a/olla/scheduler.py
+++ b/olla/scheduler.py
@@ -1,0 +1,842 @@
+import logging
+import math
+import sys
+import time
+from collections import defaultdict, OrderedDict
+
+from olla import dataflow_graph, ilp_solver
+
+
+class Scheduler:
+    def __init__(
+        self, graph, timeout_s=None, rel_stop=None, solver="GUROBI", timestep_factor=1.0
+    ):
+        self.graph = graph
+        self.timeout = timeout_s
+        self.rel_stop = rel_stop
+        self.solver = solver
+        self.num_timesteps = int(len(graph.nodes) * timestep_factor)
+
+    # Compute the earliest time a node can be scheduled. It's in the range
+    # [1, m], where m is the number of nodes in the graph.
+    def ComputeASAPSchedule(self, schedule_constraints):
+        timings = {}
+        for vertex in self.graph.nodes.values():
+            self._ComputeASAPSchedule(vertex, timings, schedule_constraints)
+        return timings
+
+    def _ComputeASAPSchedule(self, vertex, timings, schedule_constraints):
+        if vertex in timings:
+            # Already visited
+            return timings[vertex]
+        time = 1
+        for e in vertex.fanin:
+            source = e.source
+            t = self._ComputeASAPSchedule(source, timings, schedule_constraints)
+            time = max(t + 1, time)
+
+        if vertex in schedule_constraints:
+            if time > schedule_constraints[vertex]:
+                raise ValueError(
+                    "Infeasible user schedule specified for node %s" % str(vertex)
+                )
+            time = schedule_constraints[vertex]
+
+        timings[vertex] = time
+
+        return time
+
+    # Compute the latest time a node can be scheduled. It's in the range
+    # [1, m], where m is the number of nodes in the graph.
+    def ComputeALAPSchedule(self, schedule_constraints):
+        max_timesteps = self.num_timesteps
+        if schedule_constraints:
+            max_constraint = 0
+            for v in schedule_constraints.values():
+                max_constraint = max(max_constraint, v)
+            max_timesteps += max_constraint
+        timings = {}
+        for vertex in self.graph.nodes.values():
+            self._ComputeALAPSchedule(
+                vertex, timings, schedule_constraints, max_timesteps
+            )
+        return timings
+
+    def _ComputeALAPSchedule(
+        self, vertex, timings, schedule_constraints, max_timesteps
+    ):
+        if vertex in timings:
+            # Already visited
+            return timings[vertex]
+        time = max_timesteps
+        for e in vertex.fanout:
+            for sink in e.sinks:
+                t = self._ComputeALAPSchedule(
+                    sink, timings, schedule_constraints, max_timesteps
+                )
+                time = min(t - 1, time)
+
+        if vertex in schedule_constraints:
+            if time < schedule_constraints[vertex]:
+                raise ValueError(
+                    "Infeasible user schedule specified for node %s" % str(vertex)
+                )
+            time = schedule_constraints[vertex]
+
+        timings[vertex] = time
+        return time
+
+    def _GCD(self, values):
+        if len(values) == 0:
+            return 1
+        if len(values) == 1:
+            return values[0]
+        elif len(values) == 2:
+            return math.gcd(values[0], values[1])
+        else:
+            return math.gcd(values[0], self._GCD(values[1:]))
+
+    # This old formulation can't be solved quickly and supports neither
+    # swapping nor rematerialization. Use ComputeOptimalSchedule() below instead.
+    def ComputeBestSchedule(self):
+        # Compute the range of times during which each node can be alive, based
+        # purely on precedence constraints.
+        schedule_constraints = {}
+        asap = self.ComputeASAPSchedule(schedule_constraints)
+        alap = self.ComputeALAPSchedule(schedule_constraints)
+
+        solver = ilp_solver.ILPSolver(
+            timeout_s=self.timeout, rel_stop=self.rel_stop, solver=self.solver
+        )
+
+        # Create a new variable for each node
+        node_vars = {}
+        for n in self.graph.nodes.values():
+            lb = asap[n]
+            ub = alap[n]
+            v = solver.create_integer_var(n.name, lower_bound=lb, upper_bound=ub)
+            node_vars[n] = v
+
+        # Add precedence constraints
+        for e in self.graph.edges.values():
+            src = node_vars[e.source]
+            for s in e.sinks:
+                snk = node_vars[s]
+                # Add precedence constraints
+                solver.add_constraint(src <= snk - 1)
+
+        # Compute the liveness l_i_t of tensor i at timestep t
+        # Derive total memory usage
+        alive_at_t = defaultdict(lambda: {})
+        max_mem_usage = solver.create_integer_var("max_mem_usage")
+        for t in range(1, self.num_timesteps + 1):
+            mem_usage = 0
+            for n, v in node_vars.items():
+                if t < asap[n]:
+                    continue
+                for f in n.fanout:
+                    valid_sinks = []
+                    for s in f.sinks:
+                        if alap[s] < t:
+                            continue
+                        valid_sinks.append(node_vars[s])
+                    if len(valid_sinks) == 0:
+                        continue
+
+                    # Tensor i is live at timestep t iff t >= src_i and t <= max(snk_k),
+                    # where src_i is the timestep at the the op that generates i is
+                    # scheduled and snk_k are the times at which all the ops that
+                    # consume i are scheduled.
+                    # First encode l1 <=> (t >= src_i)
+                    l1 = solver.create_binary_var("l1_" + str(f.name) + "_" + str(t))
+                    solver.add_constraint(t - v <= self.num_timesteps * l1 - 1)
+                    solver.add_constraint((l1 - 1) * (self.num_timesteps - 1) <= t - v)
+
+                    # Then encode l2 <=> (t <= max(snk_k))
+                    max_snk = solver.create_integer_var(
+                        "max_snk_" + str(f.name) + "_" + str(t)
+                    )
+                    for s in valid_sinks:
+                        solver.add_constraint(max_snk >= s)
+                    l2 = solver.create_binary_var("l2_" + str(f.name) + "_" + str(t))
+                    solver.add_constraint(max_snk - t <= self.num_timesteps * l2 - 1)
+                    solver.add_constraint(
+                        (l2 - 1) * (self.num_timesteps - 1) <= max_snk - t
+                    )
+
+                    # Create a boolean variable 'live' to encode whether the
+                    # tensor is live, which is true iff l1&l2
+                    live = solver.create_binary_var("l_" + str(f.name) + "_" + str(t))
+                    solver.add_constraint(live <= l1)
+                    solver.add_constraint(live <= l2)
+                    solver.add_constraint(l1 + l2 <= 1 + live)
+                    mem_usage += live * f.size
+                    alive_at_t[t][f] = live
+
+            solver.add_constraint(max_mem_usage >= mem_usage)
+
+        solver.set_objective_function(max_mem_usage, maximize=False)
+
+        # print("PROBLEM STATS = " + str(solver))
+        schedule = {}
+        result = solver.solve()
+        for n, v in node_vars.items():
+            schedule[n] = result[v]
+
+        peak_mem_usage = 0
+        for t, vars in alive_at_t.items():
+            memory_usage = 0
+            for e, v in vars.items():
+                if result[v] == 1:
+                    # print(e.name + " IS LIVE AT T=" + str(t))
+                    memory_usage += e.size
+            if memory_usage > peak_mem_usage:
+                peak_mem_usage = memory_usage
+
+        return (peak_mem_usage, schedule)
+
+    # Compute the optimal memory schedule. Returns the (summary, schedule)
+    # pair, where summary is a map containing the following entries:
+    #   peak_mem_usage: maximum total size of the tensors at any time
+    #   total_data_swapped: total amount of data spilled and restored
+    #   required_memory: total amount of memory needed to run the model. This
+    #   corresponds to the peak_memory_usage plus space wasted due to
+    #   fragmentation
+    def ComputeOptimalSchedule(
+        self,
+        mem_limit=sys.maxsize,
+        allow_rematerialization=False,
+        allow_swaps=False,
+        account_for_fragmentation=False,
+        defrag=False,
+        user_schedule=None,
+        max_spills=None,
+    ):
+        # Compute the minimum amount of memory required to run the graph.
+        min_memory_requirement = 0
+        for n in self.graph.nodes.values():
+            mem_needed = 0
+            for e in n.fanin:
+                mem_needed += e.size
+            for e in n.fanout:
+                mem_needed += e.size
+            min_memory_requirement = max(min_memory_requirement, mem_needed)
+
+        if min_memory_requirement > mem_limit:
+            raise ValueError(
+                "The graph requires at least %d bytes to run (limit: %d)"
+                % (min_memory_requirement, mem_limit)
+            )
+            logging.info(
+                "largest working set %d fits within limit %d, proceeding...",
+                min_memory_requirement,
+                mem_limit,
+            )
+
+        schedule_constraints = {}
+        if user_schedule is not None:
+            for n, ts in user_schedule.items():
+                if ts <= 0:
+                    raise ValueError(
+                        "Negative or null timestep specified for node %s" % str(n)
+                    )
+                if isinstance(n, str):
+                    name = n
+                else:
+                    assert isinstance(n, dataflow_graph.Node)
+                    name = n.name
+                if name not in self.graph.nodes:
+                    print(
+                        "Invalid schedule: node "
+                        + name
+                        + " does not exist in the graph"
+                    )
+                    continue
+                n = self.graph.nodes[name]
+                schedule_constraints[n] = ts
+
+        # Compute the range of times during which each tensor can be alive, based
+        # purely on precedence constraints.
+        asap = self.ComputeASAPSchedule(schedule_constraints)
+        alap = self.ComputeALAPSchedule(schedule_constraints)
+        makespan = {}
+        for n in self.graph.nodes.values():
+            lb = asap[n]
+            for e in n.fanout:
+                ub = alap[n]
+                for snk in e.sinks:
+                    assert alap[snk] > alap[n]
+                    ub = max(ub, alap[snk])
+                makespan[e] = (lb, ub)
+                # print(e.name + "[" + str(lb) + ", " + str(up) + "]")
+
+        solver = ilp_solver.ILPSolver(
+            timeout_s=self.timeout, rel_stop=self.rel_stop, solver=self.solver
+        )
+
+        # Create 2 new variable for each tensor and timestep: generate and preserve
+        generate_vars = defaultdict(lambda: {})
+        preserve_vars = defaultdict(lambda: {})
+        fetch_vars = defaultdict(lambda: {})
+
+        for e in self.graph.edges.values():
+            lb, ub = makespan[e]
+            for t in range(lb, ub + 1):
+                v = solver.create_binary_var(e.name + "_generate_ts" + str(t))
+                generate_vars[e][t] = v
+                v = solver.create_binary_var(e.name + "_preserve_ts" + str(t))
+                preserve_vars[e][t] = v
+                v = solver.create_binary_var(e.name + "_fetch_ts" + str(t))
+                fetch_vars[e][t] = v
+
+            if e.source in schedule_constraints:
+                ts = schedule_constraints[e.source]
+                assert ts >= lb
+                assert ts <= ub
+                for t in range(lb, ub + 1):
+                    if t != ts:
+                        solver.add_constraint(generate_vars[e][t] == 0)
+                    else:
+                        solver.add_constraint(generate_vars[e][t] == 1)
+
+            for snk in e.sinks:
+                if snk in schedule_constraints:
+                    ts = schedule_constraints[snk]
+                    assert ts >= lb
+                    assert ts <= ub
+                    solver.add_constraint(preserve_vars[e][ts] == 1)
+
+        # Add correctness constraints: we can't preserve data unless it's been
+        # generated or preserved at the previous timestep. Also it doesn't make
+        # sense to preserve and compute some data at the same timestep
+        for e in self.graph.edges.values():
+            lb, ub = makespan[e]
+            for t in range(lb + 1, ub + 1):
+                solver.add_constraint(
+                    preserve_vars[e][t]
+                    <= preserve_vars[e][t - 1]
+                    + generate_vars[e][t - 1]
+                    + fetch_vars[e][t - 1]
+                )
+                solver.add_constraint(
+                    preserve_vars[e][t] + generate_vars[e][t] + fetch_vars[e][t] <= 1
+                )
+            # Purely to help the solver. Todo: improve the encoding to avoid
+            # creating these variables in the first place
+            solver.add_constraint(preserve_vars[e][lb] == 0)
+            solver.add_constraint(fetch_vars[e][lb] == 0)
+            solver.add_constraint(fetch_vars[e][lb + 1] == 0)
+            for t in range(alap[e.source] + 1, ub + 1):
+                solver.add_constraint(generate_vars[e][t] == 0)
+
+            # Purely to help the solver: there is no need to swap the control edges.
+            if e.size == 0 or not allow_swaps:
+                for t in range(lb + 2, ub + 1):
+                    solver.add_constraint(fetch_vars[e][t] == 0)
+
+            # Control edges are always available once they've been triggered.
+            if e.size == 0:
+                for t in range(lb + 1, ub + 1):
+                    solver.add_constraint(
+                        preserve_vars[e][t]
+                        >= preserve_vars[e][t - 1] + generate_vars[e][t - 1]
+                    )
+
+        # Add precedence constraints: we need all the nodes inputs to be
+        # available in memory at time t in order to evaluate the node.
+        # We also ensure that all the fanouts of a node are generated at the
+        # same time. This is only an optimization, since the objective of
+        # minimizing the number of computation would take care of that on its on.
+        for n in self.graph.nodes.values():
+            lb = asap[n]
+            ub = alap[n]
+            if len(n.fanout) > 1:
+                for i in range(1, len(n.fanout)):
+                    for t in range(lb, ub + 1):
+                        solver.add_constraint(
+                            generate_vars[n.fanout[0]][t]
+                            == generate_vars[n.fanout[i]][t]
+                        )
+
+            for snk in n.fanout:
+                for src in n.fanin:
+                    # Add precedence constraints
+                    for t in range(lb, ub + 1):
+                        solver.add_constraint(
+                            generate_vars[snk][t]
+                            <= preserve_vars[src][t] + fetch_vars[src][t]
+                        )
+
+        # We can't swap the data back in unless it's already been generated
+        # (and implicitely swapped out instead of being simply discarded).
+        # Moreover the data must have been generated at least 2 timesteps
+        # before it is fetched back, otherwise it would have been cheaper to
+        # simply preserve the data in memory.
+        for e in self.graph.edges.values():
+            lb, ub = makespan[e]
+            ub = min(ub, alap[e.source] + 1)
+            previously_generated = generate_vars[e][lb]
+            for t in range(lb + 2, ub + 1):
+                solver.add_constraint(fetch_vars[e][t] <= previously_generated)
+                previously_generated += generate_vars[e][t - 1]
+
+        # Force the generation of each tensor at least once (or exactly once if
+        # rematerialization is not allowed)
+        for ts in generate_vars.values():
+            s = 0
+            for v in ts.values():
+                s += v
+            if allow_rematerialization:
+                solver.add_constraint(1 <= s)
+            else:
+                solver.add_constraint(1 == s)
+
+        # A node needs to consume all its inputs at the same timestep. Handle
+        # the case where the node has no fanout below. The case where the node
+        # has fanout is already handled.
+        for n in self.graph.nodes.values():
+            if len(n.fanout) > 0:
+                continue
+            if len(n.fanin) <= 1:
+                continue
+            # We need at least one timestep during which all the inputs are live at the same time
+            lb, ub = makespan[n.fanin[0]]
+            for i in range(1, len(n.fanin)):
+                nlb, nub = makespan[n.fanin[i]]
+                lb = max(lb, nlb)
+                ub = min(ub, nub)
+            sum_of_all_live = 0
+            for t in range(lb, ub + 1):
+                all_live = solver.create_binary_var(
+                    "fanin_of_" + n.name + "_live_at_ts" + str(t)
+                )
+                sum_of_preserve_var = 0
+                for f in n.fanin:
+                    sum_of_preserve_var += preserve_vars[f][t]
+                solver.add_constraint(
+                    (all_live - 1) * len(n.fanin) <= sum_of_preserve_var - len(n.fanin)
+                )
+                solver.add_constraint(
+                    sum_of_preserve_var - len(n.fanin) >= (all_live - 1) * len(n.fanin)
+                )
+                sum_of_all_live += all_live
+            solver.add_constraint(sum_of_all_live >= 1)
+
+        # Memory usage at each timestep
+        mem_at_timestep = defaultdict(lambda: 0)
+        for e, ts in preserve_vars.items():
+            for t, v in ts.items():
+                if e.size > 0:
+                    mem_at_timestep[t] += v * e.size
+        for e, ts in generate_vars.items():
+            for t, v in ts.items():
+                if e.size > 0:
+                    mem_at_timestep[t] += v * e.size
+        for e, ts in fetch_vars.items():
+            for t, v in ts.items():
+                if e.size > 0:
+                    mem_at_timestep[t] += v * e.size
+
+        if max_spills is None:
+            # We need to fit withing the memory budget at each timestep
+            for mem_usage in mem_at_timestep.values():
+                solver.add_constraint(mem_usage <= mem_limit)
+        else:
+            # We need to ensure that we don't exceed our total spill budget
+            spills_per_tensor = defaultdict(lambda: 0)
+            for e, ts in fetch_vars.items():
+                if e.size > 0:
+                    for _, v in ts.items():
+                        spills_per_tensor[e] += v
+
+            total_spills = 0
+            for e, s in spills_per_tensor.items():
+                is_spilled = solver.create_binary_var("is_" + e.name + "_spilled")
+                solver.add_constraint(is_spilled <= s)
+                lb, ub = makespan[e]
+                max_timesteps = ub - lb + 1
+                solver.add_constraint(is_spilled * max_timesteps >= s)
+                s += is_spilled
+                s *= e.size
+                total_spills += s
+            solver.add_constraint(total_spills <= max_spills)
+
+        if account_for_fragmentation and not defrag:
+            # GCD
+            tensor_sizes = [t.size for t in self.graph.edges.values() if t.size > 0]
+            gcd = self._GCD(tensor_sizes)
+
+            # Track the maximum address that can be used
+            max_address = solver.create_integer_var("max_address", lower_bound=0)
+            solver.add_constraint(max_address <= mem_limit // gcd)
+
+            total_size = 0
+            # Create a new variable for each tensor that tracks the base address
+            # of the tensor. If the tensor is of size 0, we force its address to be
+            # 0 to help the solver
+            addresses = OrderedDict()
+            for tensor in self.graph.edges.values():
+                if tensor.size > 0:
+                    v = solver.create_integer_var(tensor.name, lower_bound=0)
+                    addresses[tensor] = v
+                    solver.add_constraint(v + tensor.size // gcd <= max_address)
+                    total_size += tensor.size // gcd
+                else:
+                    addresses[tensor] = 0
+
+            solver.add_constraint(max_address <= total_size)
+
+            processed = set()
+            for t1, span1 in makespan.items():
+                if t1.size == 0:
+                    continue
+                # Help the solver by providing upper bounds for all the addresses
+                solver.add_constraint(addresses[t1] + t1.size // gcd <= total_size)
+                for t2, span2 in makespan.items():
+                    if t2.size == 0:
+                        continue
+                    if t1 is t2 or (t2, t1) in processed:
+                        continue
+                    processed.add((t1, t2))
+                    if (
+                        span1[1] < span2[0]
+                        or span1[0] > span2[1]
+                        or not self.graph.can_overlap_in_time(t1, t2)
+                    ):
+                        # print(t1.name + " and " + t2.name + "CANNOT OVERLAP")
+                        continue
+                    if span1[1] >= span2[0] and span1[0] <= span2[1]:
+                        # The spans may overlap: if they do, one of these 2 constraints must hold:
+                        # variables[t1] + t1.size <= variables[t2]
+                        # variables[t1] >= variables[t2] + t2.size
+                        v1 = solver.create_binary_var(t1.name + "_" + t2.name + "_v1")
+                        solver.add_constraint(
+                            addresses[t1] + t1.size // gcd - addresses[t2]
+                            <= (1 - v1) * total_size
+                        )
+                        v2 = solver.create_binary_var(t1.name + "_" + t2.name + "_v2")
+                        solver.add_constraint(
+                            addresses[t1] - addresses[t2] - t2.size // gcd
+                            >= (v2 - 1) * total_size
+                        )
+
+                        # check if they actually do overlap
+                        overlap = solver.create_binary_var(
+                            t1.name + "_" + t2.name + "_overlap"
+                        )
+                        # sum_overlaps = 0
+                        for ts in range(
+                            max(span1[0], span2[0]), min(span1[1], span2[1]) + 1
+                        ):
+                            live1 = (
+                                generate_vars[t1][ts]
+                                + preserve_vars[t1][ts]
+                                + fetch_vars[t1][ts]
+                            )
+                            live2 = (
+                                generate_vars[t2][ts]
+                                + preserve_vars[t2][ts]
+                                + fetch_vars[t2][ts]
+                            )
+                            # overlap_at_t = solver.create_binary_var(
+                            #    t1.name + "_" + t2.name + "_overlap_at_" + str(ts)
+                            # )
+                            # solver.add_constraint(overlap_at_t <= live1)
+                            # solver.add_constraint(overlap_at_t <= live2)
+                            # solver.add_constraint(overlap_at_t + 1 >= live1 + live2)
+                            overlap_at_t = live1 + live2 - 1
+                            solver.add_constraint(overlap >= overlap_at_t)
+                            # sum_overlaps += overlap_at_t
+
+                        # solver.add_constraint(overlap <= sum_overlaps)
+
+                        solver.add_constraint(v1 + v2 >= overlap)
+                        # solver.add_constraint(2 - v1 - v2 >= overlap)
+
+        #####################################################
+
+        elif defrag:
+            # GCD
+            tensor_sizes = [t.size for t in self.graph.edges.values() if t.size > 0]
+            gcd = self._GCD(tensor_sizes)
+
+            # Maximum address that can be used
+            max_address = mem_limit // gcd
+
+            # Create a new variable for each tensor that tracks the base address
+            # of the tensor. If the tensor is of size 0, we force its address to be
+            # 0 to help the solver
+            addresses = defaultdict(lambda: {})
+            for tensor in self.graph.edges.values():
+                lb, ub = makespan[tensor]
+                for t in range(lb, ub + 1):
+                    if tensor.size > 0:
+                        v = solver.create_integer_var(
+                            tensor.name + "@" + str(t),
+                            lower_bound=0,
+                            upper_bound=max_address - tensor.size // gcd,
+                        )
+                        # solver.add_constraint(v + tensor.size // gcd <= max_address)
+                        addresses[tensor][t] = v
+                    else:
+                        addresses[tensor][t] = 0
+
+            for e in self.graph.edges.values():
+                if e.size == 0:
+                    continue
+                lb, ub = makespan[e]
+                for t in range(lb + 1, ub + 1):
+                    # If preserve[t], then address[t] must be equal to address[t-1]. This is encoded as:
+                    # address[t] - address[t-1] <= (1-preserve) * max_address
+                    # address[t-1] - address[t] <= (1-preserve) * max_address
+                    solver.add_constraint(
+                        addresses[e][t] - addresses[e][t - 1]
+                        <= (1 - preserve_vars[e][t]) * max_address
+                    )
+                    solver.add_constraint(
+                        addresses[e][t - 1] - addresses[e][t]
+                        <= (1 - preserve_vars[e][t]) * max_address
+                    )
+
+            liveness = defaultdict(lambda: [])
+            for e in self.graph.edges.values():
+                if e.size == 0:
+                    continue
+                lb, ub = makespan[e]
+                for ts in range(lb, ub + 1):
+                    liveness[ts].append(e)
+
+            for ts, edges in liveness.items():
+                processed = set()
+                for t1 in edges:
+                    for t2 in edges:
+                        if t1 is t2 or (t2, t1) in processed:
+                            continue
+                        processed.add((t1, t2))
+                        if not self.graph.can_overlap_in_time(t1, t2):
+                            # print(t1.name + " and " + t2.name + "CANNOT OVERLAP 2")
+                            continue
+                        # Check if both t1 and t2 are live at ts.
+                        live1 = (
+                            generate_vars[t1][ts]
+                            + preserve_vars[t1][ts]
+                            + fetch_vars[t1][ts]
+                        )
+                        live2 = (
+                            generate_vars[t2][ts]
+                            + preserve_vars[t2][ts]
+                            + fetch_vars[t2][ts]
+                        )
+                        # overlap_at_ts = solver.create_binary_var(
+                        #    t1.name + "_" + t2.name + "_overlap_at_" + str(ts)
+                        # )
+                        # solver.add_constraint(overlap_at_ts <= live1)
+                        # solver.add_constraint(overlap_at_ts <= live2)
+                        # solver.add_constraint(overlap_at_ts + 1 >= live1 + live2)
+                        # Make sure overlap at ts < 1 if the 2 tensors don't overlap in time.
+                        overlap_at_ts = live1 + live2 - 1
+
+                        # if t1 and t2 are both live at ts, one of these 2 constraints must hold:
+                        # variables[t1] + t1.size <= variables[t2]
+                        # variables[t1] >= variables[t2] + t2.size
+                        # If the size of t1 is the same as the size of t2, we only use the first
+                        # constraint.
+                        if False:  # t1.size == t2.size:
+                            v1 = solver.create_binary_var(
+                                t1.name + "_" + t2.name + "_v1_at_" + str(ts)
+                            )
+                            solver.add_constraint(
+                                addresses[t1][ts] + t1.size // gcd - addresses[t2][ts]
+                                <= (1 - v1) * max_address
+                            )
+                            solver.add_constraint(overlap_at_ts <= v1)
+                        else:
+                            v1 = solver.create_binary_var(
+                                t1.name + "_" + t2.name + "_v1_at_" + str(ts)
+                            )
+                            solver.add_constraint(
+                                addresses[t1][ts] + t1.size // gcd - addresses[t2][ts]
+                                <= (1 - v1) * max_address
+                            )
+                            v2 = solver.create_binary_var(
+                                t1.name + "_" + t2.name + "_v2_at_" + str(ts)
+                            )
+                            solver.add_constraint(
+                                addresses[t1][ts] - addresses[t2][ts] - t2.size // gcd
+                                >= (v2 - 1) * max_address
+                            )
+
+                            solver.add_constraint(v1 + v2 >= overlap_at_ts)
+                            # solver.add_constraint(2 - v1 - v2 >= overlap_at_ts)
+
+        #####################################################
+
+        # Add objective function
+        s = 0
+        if allow_rematerialization:
+            # Minimize the number of data generations
+            for e, ts in generate_vars.items():
+                for v in ts.values():
+                    s += v * e.size
+
+        if max_spills is None:
+            # Minimize the number of spills
+            for e, ts in fetch_vars.items():
+                for v in ts.values():
+                    s += v * e.size * 2
+        else:
+            # Minimize peak memory usage
+            if defrag:
+                v = solver.create_integer_var(
+                    "peak_memory_usage",
+                    lower_bound=min_memory_requirement,
+                    upper_bound=mem_limit,
+                )
+                s += v
+                for t, p in addresses.items():
+                    for a in p.values():
+                        solver.add_constraint(v >= a * gcd + t.size)
+            elif account_for_fragmentation:
+                v = solver.create_integer_var(
+                    "peak_memory_usage",
+                    lower_bound=min_memory_requirement,
+                    upper_bound=mem_limit,
+                )
+                s += v
+                for t, a in addresses.items():
+                    solver.add_constraint(v >= a * gcd + t.size)
+            else:
+                v = solver.create_integer_var(
+                    "peak_memory_usage",
+                    lower_bound=min_memory_requirement,
+                    upper_bound=mem_limit,
+                )
+                s += v
+                for m in mem_at_timestep.values():
+                    solver.add_constraint(v >= m)
+
+        solver.set_objective_function(s, maximize=False)
+
+        start_time = time.time()
+        print("Start ILP solve")
+        # print("PROBLEM STATS = " + str(solver))
+        solver.write("/tmp/scheduler_solver.txt")
+        result = solver.solve()
+        print(f"ILP solve time: {time.time()-start_time} seconds")
+
+        last_uses = {}
+        for e in self.graph.edges.values():
+            last_use = 0
+            for sink in e.sinks:
+                if len(sink.fanout) == 0:
+                    last_use = max(last_use, alap[sink])
+                else:
+                    for fanout in sink.fanout:
+                        for t, v in generate_vars[fanout].items():
+                            if result[v] >= 0.99:
+                                last_use = max(last_use, t)
+
+            last_uses[e] = last_use
+
+        schedule = defaultdict(lambda: ([], [], []))
+        mem_locations = defaultdict(lambda: {})
+        for n, ts in generate_vars.items():
+            for t, v in ts.items():
+                if result[v] >= 0.99:
+                    if account_for_fragmentation:
+                        if n.size == 0:
+                            schedule[n][0].append(str(t) + "[ctrl]")
+                        else:
+                            if defrag:
+                                schedule[n][0].append(
+                                    str(t)
+                                    + "@"
+                                    + str(int(result[addresses[n][t]] * gcd))
+                                )
+                                mem_locations[t][n] = int(result[addresses[n][t]] * gcd)
+                            else:
+                                schedule[n][0].append(
+                                    str(t) + "@" + str(int(result[addresses[n]] * gcd))
+                                )
+                                mem_locations[t][n] = int(result[addresses[n]] * gcd)
+
+                    else:
+                        schedule[n][0].append(t)
+
+        for n, ts in preserve_vars.items():
+            for t, v in ts.items():
+                if t > last_uses[n]:
+                    continue
+                if result[v] >= 0.99:
+                    schedule[n][1].append(t)
+                    if n.size == 0:
+                        continue
+                    if defrag:
+                        mem_locations[t][n] = int(result[addresses[n][t]] * gcd)
+                    elif account_for_fragmentation:
+                        mem_locations[t][n] = int(result[addresses[n]] * gcd)
+
+        for n, ts in fetch_vars.items():
+            for t, v in ts.items():
+                if t > last_uses[n]:
+                    continue
+                if result[v] >= 0.99:
+                    if defrag:
+                        schedule[n][2].append(
+                            str(t) + "@" + str(int(result[addresses[n][t]] * gcd))
+                        )
+                        mem_locations[t][n] = int(result[addresses[n][t]] * gcd)
+                    else:
+                        schedule[n][2].append(t)
+                        if account_for_fragmentation:
+                            mem_locations[t][n] = int(result[addresses[n]] * gcd)
+
+        mem_at_timestep = defaultdict(lambda: 0)
+        tensors_swapped = defaultdict(lambda: 0)
+        for e, ts in preserve_vars.items():
+            for t, v in ts.items():
+                if t <= last_uses[e]:
+                    mem_at_timestep[t] += result[v] * e.size
+        for e, ts in generate_vars.items():
+            for t, v in ts.items():
+                if t <= last_uses[e]:
+                    mem_at_timestep[t] += result[v] * e.size
+        for e, ts in fetch_vars.items():
+            for t, v in ts.items():
+                if t > last_uses[e]:
+                    continue
+                mem_at_timestep[t] += result[v] * e.size
+                if result[v] >= 0.99:
+                    tensors_swapped[e] += 1
+
+        peak_mem_usage = 0
+        for mem_usage in mem_at_timestep.values():
+            peak_mem_usage = max(peak_mem_usage, mem_usage)
+
+        total_data_swapped = 0
+        for e, count in tensors_swapped.items():
+            total_data_swapped += (count + 1) * e.size
+
+        if defrag:
+            required_memory = 0
+            for t, p in addresses.items():
+                if t.size == 0:
+                    continue
+                for timestamp, a in p.items():
+                    if timestamp <= last_uses[e]:
+                        required_memory = max(required_memory, result[a] * gcd + t.size)
+        elif account_for_fragmentation:
+            required_memory = 0
+            for t, a in addresses.items():
+                if t.size == 0:
+                    continue
+                required_memory = max(required_memory, result[a] * gcd + t.size)
+        else:
+            required_memory = peak_mem_usage
+
+        summary = {
+            "peak_mem_usage": peak_mem_usage,
+            "total_data_swapped": total_data_swapped,
+            "required_memory": required_memory,
+        }
+        return (summary, schedule, mem_locations)

--- a/olla/simulator.py
+++ b/olla/simulator.py
@@ -1,0 +1,32 @@
+from collections import defaultdict
+
+
+class Simulator:
+    def __init__(self, graph):
+        self.graph = graph
+
+    def Simulate(self, node_ordering):
+        edge_ref_counts = defaultdict(lambda: 0)
+
+        memory_used = self.graph.unused_weight_size
+        peak_memory = 0
+        mem_per_timestep = []
+        for n in node_ordering:
+            for fanout in n.fanout:
+                if fanout.size > 0:
+                    edge_ref_counts[fanout] = len(fanout.sinks)
+                    memory_used += fanout.size
+
+            if memory_used > peak_memory:
+                peak_memory = memory_used
+            mem_per_timestep.append((n, memory_used))
+
+            for fanin in n.fanin:
+                if fanin.size == 0:
+                    continue
+                edge_ref_counts[fanin] -= 1
+                assert edge_ref_counts[fanin] >= 0
+                if edge_ref_counts[fanin] == 0:
+                    memory_used -= fanin.size
+
+        return (peak_memory, mem_per_timestep)

--- a/olla/torch/fx_optimizer.py
+++ b/olla/torch/fx_optimizer.py
@@ -1,0 +1,9 @@
+import torch
+
+
+class TraceOptimizer:
+    def __init__(self, fx_trace):
+        self.fx_trace = fx_trace
+
+    def Reorder(self, optimizer_result):
+        pass

--- a/olla/torch/fx_profiler.py
+++ b/olla/torch/fx_profiler.py
@@ -1,0 +1,113 @@
+import statistics
+import time
+from typing import Any, List, Optional, OrderedDict, Union
+
+import numpy as np
+
+import pandas as pd
+
+import torch
+
+
+class ProfilingInterpreter(torch.fx.Interpreter):
+    def __init__(
+        self,
+        gm: torch.fx.GraphModule,
+        profile_memory: bool = True,
+        profile_time: bool = False,
+        warm_up_iters: int = 0,
+        profile_iters: int = 1,
+    ):
+        super().__init__(gm)
+        self.profile_memory = profile_memory
+        self.profile_time = profile_time
+        self.warm_up_iters = warm_up_iters
+        self.profile_iters = profile_iters
+        if self.profile_memory:
+            assert (
+                torch.cuda.is_available()
+            ), "Currently memory profile is only supported on CUDA"
+        self.total_runtime_sec: List[float] = []
+        self.node_profiles = OrderedDict()
+        self.warm_up = False
+
+    def run(self, *args) -> Any:
+        for _ in range(self.warm_up_iters):
+            # running without profiling
+            # print(f"warm up execution iteration {i}")
+            self.warm_up = True
+            super().run(*args)
+            self.warm_up = False
+
+        for _ in range(self.profile_iters):
+            # Measure total runtime to run the model
+            t_start = time.time()
+            # print(f"profile execution iteration {i}")
+            return_val = super().run(*args)
+            t_end = time.time()
+            self.total_runtime_sec.append(t_end - t_start)
+        return return_val
+
+    def run_node(self, n: torch.fx.Node) -> Any:
+        return_val = None
+        try:
+            if self.profile_time and not self.warm_up:
+                # TODO: use a more accurate method to profile time, e.g., timeit
+                t_start = time.time()
+                return_val = super().run_node(n)
+                t_end = time.time()
+                self.node_profiles.setdefault(n, OrderedDict())
+                self.node_profiles[n].setdefault("runtimes_sec", [])
+                self.node_profiles[n]["runtimes_sec"].append(t_end - t_start)
+            else:
+                return_val = super().run_node(n)
+
+            if self.profile_memory and not self.warm_up:
+                memory_stats = torch.cuda.memory_stats()
+                assert (
+                    memory_stats
+                ), "torch.cuda.memory_stats() returned an empty result. This could be because the model or tensors were not transferred to GPU. Make sure to call `model.cuda()` and `input = input.cuda()` on all the model's inputs."
+                self.node_profiles.setdefault(n, OrderedDict())
+                for k in memory_stats.keys():
+                    self.node_profiles[n].setdefault(k, [])
+                    self.node_profiles[n][k].append(memory_stats[k])
+        except RuntimeError:
+            pass  # warnings.warn(f"Unable to profile node {n.name}", RuntimeWarning)
+
+        return return_val
+
+    # TODO: decouple calculating averages from printing the result, and hence always calculate averages at the end of profiling
+    def summary(self, sort_by: Optional[Union[str, List[str]]] = None) -> str:
+        table = pd.DataFrame()
+        # Can be used later if we want percentage time of each node with respect to whole model
+        mean_total_runtime = statistics.mean(self.total_runtime_sec)  # noqa
+
+        # For each node, record max_required_memory and allocated_mem_at_max, and mean statistics for other measurements
+        for node, profiles in self.node_profiles.items():
+            row = OrderedDict()
+
+            row["Op name"] = node.name
+            row["Op type"] = node.op
+            for name, values in profiles.items():
+                if name == "allocated_bytes.all.current":
+                    continue
+                elif name == "reserved_bytes.all.current":
+                    imax = np.argmax(np.asarray(values))
+                    max_required_memory = values[imax]
+                    allocated_mem_at_max = profiles["allocated_bytes.all.current"][imax]
+                    row["reserved_bytes.all.current"] = max_required_memory
+                    row["allocated_bytes.all.current"] = allocated_mem_at_max
+                else:
+                    row[name] = statistics.mean(values)
+            table = pd.concat([table, pd.Series(row).to_frame().T], ignore_index=True)
+
+        # ensure that the first 3 columns are: Op name, Op type, runtime
+        table.insert(0, "Op name", table.pop("Op name"))
+        table.insert(1, "Op type", table.pop("Op type"))
+        if self.profile_time:
+            table.insert(2, "runtimes_sec", table.pop("runtimes_sec"))
+
+        if sort_by:
+            table.sort_values(sort_by)
+
+        return pd.DataFrame(table)

--- a/olla/torch/max_cut_test.py
+++ b/olla/torch/max_cut_test.py
@@ -1,0 +1,172 @@
+import time
+import unittest
+
+import torch
+import torch.fx
+import torchvision
+
+from olla import max_cut
+from olla.torch import torch_graph_importer
+
+
+class MaxCutTest(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+        # limit = 20 * 1024 * 1024 * 1024
+        # resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
+
+    def run_test(self, model, input, mode, expected_cut):
+        start = time.time()
+        g, pt_node_order = self.importer.import_via_aotautograd(
+            model,
+            *input,
+            optimizer=True,
+            mode=mode,
+        )
+        g.canonicalize()
+        g.constrain_weight_updates()
+        self.assertTrue(g.is_valid())
+
+        start = time.time()
+        mc = max_cut.MaxCut(g, debug=True, rel_stop=0.01)
+        cut_size, cut = mc.LocateCut()
+        stop = time.time()
+        print(f"Located max cut in {stop-start} seconds")
+        cut = [t.name for t in cut]
+        print(str(cut))
+        self.assertEqual(cut, expected_cut)
+
+    def testVGGInference(self):
+        model = torchvision.models.vgg11()
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(model, (input,), "eval", ["max_pool2d_with_indices"])
+
+    def testVGGTraining(self):
+        model = torchvision.models.vgg11()
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model,
+            (input,),
+            "train",
+            [
+                "args_1",
+                "convolution",
+                "convolution_1",
+                "convolution_2",
+                "convolution_3",
+                "convolution_4",
+                "convolution_5",
+                "convolution_6",
+                "convolution_7",
+                "threshold_backward_1",
+                "mm_5",
+                "_adaptive_avg_pool2d_backward",
+                "max_pool2d_with_indices",
+                "max_pool2d_with_indices",
+                "max_pool2d_with_indices_1",
+                "max_pool2d_with_indices_1",
+                "max_pool2d_with_indices_2",
+                "max_pool2d_with_indices_2",
+                "max_pool2d_with_indices_3",
+                "max_pool2d_with_indices_3",
+                "max_pool2d_with_indices_4",
+            ],
+        )
+
+    def testResnetInference(self):
+        model = torchvision.models.resnet18(norm_layer=torch.nn.Identity)
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model, (input,), "eval", ["convolution_2", "max_pool2d_with_indices"]
+        )
+
+    def testResnetTraining(self):
+        model = torchvision.models.resnet18(norm_layer=torch.nn.Identity)
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model,
+            (input,),
+            "train",
+            [
+                "args_1",
+                "convolution",
+                "convolution_1",
+                "convolution_2",
+                "convolution_3",
+                "convolution_4",
+                "convolution_5",
+                "convolution_6",
+                "convolution_8",
+                "convolution_9",
+                "convolution_10",
+                "convolution_11",
+                "convolution_13",
+                "convolution_14",
+                "convolution_15",
+                "max_pool2d_with_indices",
+                "max_pool2d_with_indices",
+                "convolution_backward_2",
+                "convolution_backward_2",
+                "convolution_backward_3",
+                "convolution_backward_3",
+            ],
+        )
+
+    def testTransformerDecoderLayerInference(self):
+        model = torch.nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        memory = torch.rand(10, 32, 512)
+        tgt = torch.rand(20, 32, 512)
+        self.run_test(
+            model,
+            (memory, tgt),
+            "eval",
+            [
+                "args_1",
+                "addmm",
+                "clone_1",
+                "div",
+                "addmm_3",
+                "clone_4",
+            ],
+        )
+
+    def testTransformerDecoderLayerTrain(self):
+        model = torch.nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        memory = torch.rand(10, 32, 512)
+        tgt = torch.rand(20, 32, 512)
+        self.run_test(
+            model,
+            (memory, tgt),
+            "train",
+            [
+                "args_1",
+                "args_2",
+                "clone_1",
+                "clone_2",
+                "div",
+                "_softmax",
+                "empty_like",
+                "mul",
+                "clone_3",
+                "empty_like_1",
+                "add",
+                "clone_4",
+                "clone_5",
+                "div_1",
+                "_softmax_1",
+                "empty_like_2",
+                "mul_2",
+                "clone_6",
+                "empty_like_3",
+                "add_1",
+                "relu",
+                "mul_6",
+                "mm_1",
+                "mul_7",
+                "native_layer_norm",
+                "native_layer_norm",
+                "native_layer_norm_1",
+                "native_layer_norm_1",
+                "native_layer_norm_backward",
+            ],
+        )

--- a/olla/torch/memory_optimizer_test.py
+++ b/olla/torch/memory_optimizer_test.py
@@ -1,0 +1,260 @@
+import os
+
+# import resource
+import time
+import unittest
+
+import torch
+import torch.fx
+import torchvision
+
+from olla import simulator, training_graph_optimizer, utils
+from olla.torch import torch_graph_importer
+
+# Fix the environment to enable graphviz to work.
+del os.environ["LD_LIBRARY_PATH"]
+
+
+class MemoryOptimizerTest(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+        # limit = 20 * 1024 * 1024 * 1024
+        # resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
+
+    def run_test(
+        self, model, input, mode, tests, timestep_factor=1, memory_reduction_factor=1.0
+    ):
+        start = time.time()
+        g, pt_node_order = self.importer.import_via_aotautograd(
+            model,
+            *input,
+            optimizer=True,
+            mode=mode,
+        )
+        model_name = model.__class__.__name__
+        # print(str(g))
+        if "dump" in tests:
+            g.dump("/tmp/" + model_name + "_" + mode + "_raw", format="svg")
+        g.canonicalize()
+        self.assertTrue(g.is_valid())
+        g.constrain_weight_updates()
+        self.assertTrue(g.check_consistency())
+        # print(str(g))
+        if "dump" in tests:
+            g.dump("/tmp/" + model_name + "_" + mode + "_canon", format="svg")
+        stop = time.time()
+        print(f"PREPARED {mode} GRAPH OF {model_name} IN {stop - start:.1f}s")
+
+        start = time.time()
+        s = simulator.Simulator(g)
+        simulated_mem_usage, mem_per_timestep = s.Simulate(pt_node_order)
+
+        stop = time.time()
+        print(
+            f"SIMULATED {mode} GRAPH OF {model_name} IN {stop - start:.1f}s. PEAK MEM USAGE WAS {simulated_mem_usage}"
+        )
+
+        start = time.time()
+        s = training_graph_optimizer.Scheduler(g, rel_stop=0.01, timeout_s=600)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            allow_swaps=False,
+            max_spills=0,
+        )
+        stop = time.time()
+        reordered_mem_usage = summary["peak_mem_usage"]
+        print(
+            f"REORDERED NODES FOR {mode} GRAPH OF {model_name} IN {stop - start:.1f}s. PEAK MEM USAGE WAS {reordered_mem_usage} (SAVED {(simulated_mem_usage - reordered_mem_usage) / simulated_mem_usage * 100:.1f}%)"
+        )
+
+        for s in schedule.values():
+            self.assertTrue(len(s[2]) == 0)
+        self.assertTrue(utils.validate_timeline(schedule))
+        self.assertTrue(utils.validate_node_ordering(g, schedule))
+        self.assertEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertLessEqual(summary["peak_mem_usage"], simulated_mem_usage)
+        self.assertEqual(summary["total_data_swapped"], 0)
+        # self.assertEqual(summary["peak_mem_usage"], 140274144.0)
+
+        if "spills" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(
+                g, rel_stop=0.01, timeout_s=600, timestep_factor=timestep_factor
+            )
+            min_required_memory, _ = s.ComputeMinimumMemoryRequired()
+            mem_limit = max(
+                reordered_mem_usage / memory_reduction_factor, min_required_memory
+            )
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=mem_limit,
+                allow_swaps=True,
+                max_spills=None,
+            )
+            stop = time.time()
+            peak_mem_usage = summary["peak_mem_usage"]
+            spills = summary["total_data_swapped"]
+            print(
+                f"DONE SCHEDULING SPILLS FOR {mode} GRAPH OF {model_name} IN {stop - start:.1f}s. USED {peak_mem_usage} PEAK MEM (SAVED {(simulated_mem_usage - peak_mem_usage) / simulated_mem_usage * 100:.1f}%), SPILLED {spills}"
+            )
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertEqual(summary["peak_mem_usage"], summary["required_memory"])
+            self.assertLessEqual(summary["peak_mem_usage"], mem_limit)
+            # self.assertEqual(summary["peak_mem_usage"], 46758048.0)
+
+        if "recompute" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(
+                g, rel_stop=0.01, timeout_s=600, timestep_factor=timestep_factor
+            )
+            min_required_memory, _ = s.ComputeMinimumMemoryRequired()
+            mem_limit = max(
+                reordered_mem_usage / memory_reduction_factor, min_required_memory
+            )
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=mem_limit,
+                allow_swaps=True,
+                allow_rematerialization=True,
+                max_spills=None,
+            )
+            stop = time.time()
+            peak_mem_usage = summary["peak_mem_usage"]
+            spills = summary["total_data_swapped"]
+            print(
+                f"DONE SCHEDULING RECOMPUTES FOR {mode} GRAPH OF {model_name} IN {stop - start:.1f}s. USED {peak_mem_usage} PEAK MEM (SAVED {(simulated_mem_usage - peak_mem_usage) / simulated_mem_usage * 100:.1f}%), SPILLED {spills}"
+            )
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertEqual(summary["peak_mem_usage"], summary["required_memory"])
+            self.assertLessEqual(summary["peak_mem_usage"], mem_limit)
+
+        if "memory" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(
+                g, rel_stop=0.01, timeout_s=600, timestep_factor=timestep_factor
+            )
+            min_required_memory, _ = s.ComputeMinimumMemoryRequired()
+            mem_limit = max(
+                reordered_mem_usage / memory_reduction_factor, min_required_memory
+            )
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=mem_limit,
+                allow_swaps=True,
+                max_spills=None,
+                defrag=False,
+                account_for_fragmentation=True,
+            )
+            stop = time.time()
+            peak_mem_usage = summary["required_memory"]
+            spills = summary["total_data_swapped"]
+            print(
+                f"DONE PLANNING MEMORY FOR {mode} GRAPH OF {model_name} IN {stop - start:.1f}s. USED {peak_mem_usage} REQUIRED MEM (SAVED {(simulated_mem_usage - peak_mem_usage) / simulated_mem_usage * 100:.1f}%), SPILLED {spills}"
+            )
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertTrue(utils.validate_address_allocation(mem_loc))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            self.assertLessEqual(summary["required_memory"], mem_limit)
+
+        if "defrag" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(
+                g, rel_stop=0.01, timeout_s=600, timestep_factor=timestep_factor
+            )
+            min_required_memory, _ = s.ComputeMinimumMemoryRequired()
+            mem_limit = max(
+                reordered_mem_usage / memory_reduction_factor, min_required_memory
+            )
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=mem_limit,
+                allow_swaps=True,
+                max_spills=None,
+                defrag=True,
+                account_for_fragmentation=True,
+            )
+            stop = time.time()
+            peak_mem_usage = summary["required_memory"]
+            spills = summary["total_data_swapped"]
+            print(
+                f"DONE PLANNING MEMORY DEFRAGMENTATION FOR {mode} GRAPH OF {model_name} IN {stop - start:.1f}s. USED {peak_mem_usage} REQUIRED MEM (SAVED {(simulated_mem_usage - peak_mem_usage) / simulated_mem_usage * 100:.1f}%), SPILLED {spills}"
+            )
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertTrue(utils.validate_address_allocation(mem_loc))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            self.assertLessEqual(summary["required_memory"], mem_limit)
+
+        # self.assertEqual(1, 2)
+
+    def testVGGInference(self):
+        model = torchvision.models.vgg11()
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model,
+            (input,),
+            "eval",
+            ("spills", "recompute", "memory", "defrag"),
+            timestep_factor=1.05,
+            memory_reduction_factor=1.1,
+        )
+
+    def testVGGTraining(self):
+        model = torchvision.models.vgg11()
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model,
+            (input,),
+            "train",
+            ("spills", "recompute"),
+            memory_reduction_factor=1.1,
+        )
+
+    def testResnetInference(self):
+        # Use identity as the layer normalization layer to get rid of all the dangling weights
+        model = torchvision.models.resnet18(norm_layer=torch.nn.Identity)
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model,
+            (input,),
+            "eval",
+            ("spills", "recompute", "memory"),
+            memory_reduction_factor=1.1,
+        )
+
+    def testResnetTraining(self):
+        # Use identity as the layer normalization layer to get rid of all the dangling weights
+        model = torchvision.models.resnet18(norm_layer=torch.nn.Identity)
+        input = torch.randn((1, 3, 224, 224))
+        self.run_test(
+            model,
+            (input,),
+            "train",
+            ("spills", "recompute"),
+            memory_reduction_factor=1.1,
+        )
+
+    def testTransformerDecoderLayerInference(self):
+        model = torch.nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        memory = torch.rand(10, 32, 512)
+        tgt = torch.rand(20, 32, 512)
+        self.run_test(
+            model,
+            (memory, tgt),
+            "eval",
+            ("spills", "recompute", "memory"),
+            memory_reduction_factor=1.1,
+        )
+
+    def testTransformerDecoderLayerTrain(self):
+        model = torch.nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        memory = torch.rand(10, 32, 512)
+        tgt = torch.rand(20, 32, 512)
+        # Improving the lower bound estimate on the node reordering
+        # problem takes forever, so it's disabled for now
+        self.run_test(
+            model,
+            (memory, tgt),
+            "train",
+            # ("simulate", "reordering", "spills", "recompute"),
+            ("spills", "recompute"),
+            memory_reduction_factor=1.1,
+        )

--- a/olla/torch/memory_optimizer_test_large.py
+++ b/olla/torch/memory_optimizer_test_large.py
@@ -1,0 +1,155 @@
+import os
+import time
+import unittest
+
+import torch
+import torch.fx
+
+from olla import simulator, training_graph_optimizer, utils
+from olla.torch import torch_graph_importer
+
+# Fix the environment to enable graphviz to work.
+del os.environ["LD_LIBRARY_PATH"]
+
+
+class MemoryOptimizerTest(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+
+    def run_test(self, model, input, mode, tests):
+        start = time.time()
+        g, pt_node_order = self.importer.import_via_aotautograd(
+            model,
+            *input,
+            optimizer=True,
+            mode=mode,
+        )
+        # print(str(g))
+        # g.dump("/tmp/vgg11.aotautograd.opt4ml_raw.dot")
+        # g.dump("/tmp/vgg11.aotautograd.opt4ml_raw", format="png")
+        # g.dump("/tmp/vgg11.aotautograd.opt4ml_raw", format="svg")
+        # stop = time.time()
+        g.canonicalize()
+        self.assertTrue(g.is_valid())
+        g.constrain_weight_updates()
+        self.assertTrue(g.check_consistency())
+        # print(str(g))
+        # g.dump("/tmp/vgg11.aotautograd.opt4ml.dot")
+        # g.dump("/tmp/vgg11.aotautograd.opt4ml", format="png")
+        # g.dump("/tmp/vgg11.aotautograd.opt4ml", format="svg")
+        stop = time.time()
+        print("DONE PREPARING MODEL: " + str(stop - start))
+        start = time.time()
+
+        if "simulate" in tests:
+            start = time.time()
+            s = simulator.Simulator(g)
+            peak_mem_usage, mem_per_timestep = s.Simulate(pt_node_order)
+
+            stop = time.time()
+            print("DONE SIMULATING GRAPH: " + str(stop - start))
+
+        if "reordering" in tests:
+            s = training_graph_optimizer.Scheduler(g)
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                # mem_limit=9999999999,
+                allow_swaps=False,
+                max_spills=0,
+            )
+            stop = time.time()
+            print("DONE REORDERING NODES: " + str(stop - start))
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            # self.assertEqual(summary["total_data_swapped"], 0)
+            # self.assertEqual(summary["peak_mem_usage"], 140274144.0)
+
+        if "spills" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(g, rel_stop=0.01)
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=822083584 * 2,
+                allow_swaps=True,
+                max_spills=None,
+            )
+            stop = time.time()
+            print("DONE SCHEDULING SPILLS: " + str(stop - start))
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            # self.assertEqual(summary["peak_mem_usage"], 46758048.0)
+
+        if "recompute" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(g, rel_stop=0.01)
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=822083584 * 2,
+                allow_swaps=True,
+                allow_rematerialization=True,
+                max_spills=None,
+            )
+            stop = time.time()
+            print("DONE SCHEDULING RECOMPUTES: " + str(stop - start))
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            # self.assertEqual(summary["peak_mem_usage"], 46758048.0)
+
+        if "memory" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(g, rel_stop=0.01)
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=822083584 * 2,
+                allow_swaps=True,
+                max_spills=None,
+                defrag=False,
+                account_for_fragmentation=True,
+            )
+            stop = time.time()
+            print("DONE PLANNING MEMORY: " + str(stop - start))
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            # self.assertEqual(summary["peak_mem_usage"], 46758048.0)
+
+        if "defrag" in tests:
+            start = time.time()
+            s = training_graph_optimizer.Scheduler(g, rel_stop=0.01)
+            summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+                mem_limit=822083584 * 2,
+                allow_swaps=True,
+                max_spills=None,
+                defrag=True,
+                account_for_fragmentation=True,
+            )
+            stop = time.time()
+            print("DONE PLANNING MEMORY DEFRAGMENTATION: " + str(stop - start))
+
+            self.assertTrue(utils.validate_timeline(schedule))
+            self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+            # self.assertEqual(summary["peak_mem_usage"], 46758048.0)
+
+    def testTransformerFullInference(self):
+        model = torch.nn.Transformer(
+            nhead=1, num_encoder_layers=1, num_decoder_layers=1
+        )
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((20, 32, 512))
+
+        self.run_test(
+            model,
+            (src, tgt),
+            "eval",
+            ("reordering", "spills", "recompute", "memory", "defrag"),
+        )
+
+    def testTransformerFullTrain(self):
+        model = torch.nn.Transformer(
+            nhead=1, num_encoder_layers=1, num_decoder_layers=1
+        )
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((20, 32, 512))
+
+        self.run_test(
+            model, (src, tgt), "train", ("reordering",)  # "spills", "recompute"),
+        )

--- a/olla/torch/spill_profiler.py
+++ b/olla/torch/spill_profiler.py
@@ -1,0 +1,40 @@
+import time
+
+import torch
+
+
+class SpillProfiler:
+    def __init__(self, graph, warm_up_iters=0, profile_iters=1):
+        self.graph = graph
+        self.warm_up_iters = warm_up_iters
+        self.profile_iters = profile_iters
+        self.bandwidth = 5e9
+        self.kernel_launch_time = 1e-5
+
+    def benchmark_tensor(self, tensor_size):
+        if not torch.cuda.is_available():
+            runtime = self.kernel_launch_time + tensor_size / self.bandwidth
+            return runtime
+
+        t_cpu = torch.empty(tensor_size).pin_memory()
+        t_gpu = torch.empty(tensor_size, device="cuda")
+        for _ in range(self.warm_up_iters):
+            t_cpu.copy_(t_gpu, non_blocking=True)
+            t_gpu.copy_(t_cpu, non_blocking=True)
+        torch.cuda.synchronize()
+        start = time.time()
+        for _ in range(self.profile_iters):
+            t_cpu.copy_(t_gpu, non_blocking=True)
+            t_gpu.copy_(t_cpu, non_blocking=True)
+        torch.cuda.synchronize()
+        stop = time.time()
+        # We assume that the bandwidth in and out of the gpu is roughly the same
+        runtime = (stop - start) / self.profile_iters / 2
+        return runtime
+
+    def benchmark_all(self):
+        table = {}
+        for e in self.graph.edges.values():
+            runtime = self.benchmark_tensor(e.size)
+            table[e] = runtime
+        return table

--- a/olla/torch/torch_graph_importer.py
+++ b/olla/torch/torch_graph_importer.py
@@ -1,0 +1,717 @@
+import math
+from collections.abc import Iterable
+
+# TODO: import properly from third-party library
+# import torch_tensorrt.fx.tracer.acc_tracer.acc_ops as acc_tracer
+import olla.acc_tracer.acc_tracer as acc_tracer
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.fx
+import torch.nn.utils._stateless as stateless
+from functorch import make_fx
+from functorch.compile import compiled_function, default_partition
+from olla import dataflow_graph
+from olla.torch import fx_profiler, spill_profiler
+from torch.fx.passes.shape_prop import ShapeProp
+
+# By default torch.fx.Tracer treats torch.nn.Module nodes as leaf nodes and hence doesn't trace them to obtain weight or bias nodes.
+# This class overrides this in order to enable us to obtain separate nodes for weights and biases.
+# TODO: add option for user to pass their own `is_leaf_module` function
+class DeepTracer(torch.fx.Tracer):
+    def is_leaf_module(self, m: torch.nn.Module, module_qualified_name: str) -> bool:
+        return False
+
+
+class TorchGraphImporter:
+    def __init__(self):
+        self.fx: torch.fx.GraphModule = None
+
+    # Import graph from a PyTorch model
+    def import_from_torch(
+        self,
+        model,
+        *inputs,
+        mode="eval",
+        method="fx",
+        optimizer=None,
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        return_node_ordering=False,
+    ):
+        self.assert_type(mode)
+        if method == "fx":
+            return self.import_via_fx(
+                model,
+                *inputs,
+                mode=mode,
+                profile=profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+                return_node_ordering=return_node_ordering,
+            )
+        elif method == "functorch":
+            return self.import_via_functorch(
+                model,
+                *inputs,
+                mode=mode,
+                profile=profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+                return_node_ordering=return_node_ordering,
+            )
+        elif method == "aotautograd":
+            return self.import_via_aotautograd(
+                model,
+                *inputs,
+                mode=mode,
+                optimizer=optimizer,
+                profile=profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+                return_node_ordering=return_node_ordering,
+            )
+        elif method == "acc_tracer":
+            return self.import_via_acc_tracer(
+                model,
+                *inputs,
+                mode=mode,
+                profile=profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+                return_node_ordering=return_node_ordering,
+            )
+        else:
+            raise ValueError("unsupported import type `", method, "`")
+
+    def assert_type(self, mode):
+        assert mode in ["eval", "train"], "Invalid mode provided"
+
+    def import_via_fx(
+        self,
+        model,
+        *inputs,
+        mode="eval",
+        tracer_class=DeepTracer,
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        return_node_ordering=False,
+    ):
+        self.assert_type(mode)
+        assert mode == "eval", "Currently `import_via_fx` only supports eval mode"
+
+        # tracer_class: by default is our defined DeepTracer so that we can create nodes for weights.
+        # otherwise we can use torch.fx.Tracer (won't trace weights) or any custom tracer
+        fx_trace = torch.fx.GraphModule(model, tracer_class().trace(model))
+
+        return self.import_from_fx(
+            fx_trace,
+            *inputs,
+            profile=profile,
+            warm_up_iters=warm_up_iters,
+            profile_iters=profile_iters,
+            return_node_ordering=return_node_ordering,
+        )
+
+    def import_via_functorch(
+        self,
+        model,
+        *inputs,
+        mode="train",
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        return_node_ordering=False,
+    ):
+        self.assert_type(mode)
+        # obtain the forward and backward graphs of the model
+        fx_trace_fwd = None
+        fx_trace_bwd = None
+        fx_trace_full = None
+
+        def fwd_compiler(fx_trace, example_input):
+            nonlocal fx_trace_fwd
+            fx_trace_fwd = fx_trace
+            return fx_trace
+
+        def bwd_compiler(fx_trace, example_input):
+            nonlocal fx_trace_bwd
+            fx_trace_bwd = fx_trace
+            return fx_trace
+
+        def partition(fx_trace, joint_input):
+            nonlocal fx_trace_full
+            fx_trace_full = fx_trace
+            return default_partition(fx_trace, joint_input)
+
+        compiled_function(model, fwd_compiler, bwd_compiler, partition)(*inputs)
+
+        if mode == "train":
+            fx_trace = fx_trace_full
+            outputs = model(*inputs)
+            return self.import_from_fx(
+                fx_trace,
+                *inputs,
+                *outputs,
+                profile=profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+                return_node_ordering=return_node_ordering,
+            )
+        elif mode == "eval":
+            fx_trace = fx_trace_fwd
+            return self.import_from_fx(
+                fx_trace,
+                *inputs,
+                profile=profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+                return_node_ordering=return_node_ordering,
+            )
+        else:
+            raise ValueError("unsupported import mode `", mode, "`")
+
+    def import_via_aotautograd(
+        self,
+        model,
+        *inputs,
+        mode="train",
+        optimizer=None,
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        return_node_ordering=True,
+        return_fx_graph=False,
+        verbose=True,
+    ):
+        self.assert_type(mode)
+        # TODO: if mode is train, assert that inputs have `required_grad = True`
+        def fn_model_wrapper(args, params, buffers):
+            if not isinstance(args, Iterable):
+                args = [args]
+            params_and_buffers = {**params, **buffers}
+            out = stateless.functional_call(model, params_and_buffers, args)
+            if mode == "eval":
+                return out
+            elif mode == "train":
+                out.sum().backward()
+                if optimizer is True:
+                    return [p - p.grad for p in params.values()]
+                    # return [p.sub_(1e-4 * p.grad) for p in params.values()]
+                elif optimizer is not None:
+                    optimizer.step()
+
+                # TODO: this causes graph to show an output with many incoming edges. Shall we try `return None` or simply don't return?
+                return list(params.values())
+
+        def detach_decomposition(x):
+            return x
+
+        fx_trace = make_fx(
+            fn_model_wrapper,
+            decomposition_table={torch.ops.aten.detach.default: detach_decomposition},
+        )(inputs, dict(model.named_parameters()), dict(model.named_buffers()))
+
+        # print("SYMBOLIC TRACE: \n" + str(fx_trace.graph))
+        # print("CODE FOR TRACE: \n" + str(fx_trace.code))
+
+        # aotautograd performs its own shape inference so we don't need to perform ours
+        return self.import_from_fx(
+            fx_trace,
+            *inputs,
+            *dict(model.named_parameters()).values(),
+            *dict(model.named_buffers()).values(),
+            cleanup=True,
+            shape_inference=False,
+            profile=profile,
+            warm_up_iters=warm_up_iters,
+            profile_iters=profile_iters,
+            return_node_ordering=return_node_ordering,
+            return_fx_graph=return_fx_graph,
+            verbose=verbose,
+        )
+
+    def import_via_acc_tracer(
+        self,
+        model,
+        *inputs,
+        mode="eval",
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        return_node_ordering=False,
+    ):
+        self.assert_type(mode)
+        assert (
+            mode == "eval"
+        ), "Currently `import_via_acc_tracer` only supports eval mode"
+
+        self.fx_trace = acc_tracer.trace(model, inputs, use_acc_shape_inference=True)
+        # acc_tracer executes its own shape propagation so we can import from fx without performing our shape propagation
+        return self.import_from_fx(
+            self.fx_trace,
+            *inputs,
+            shape_inference=False,
+            profile=profile,
+            warm_up_iters=warm_up_iters,
+            profile_iters=profile_iters,
+            return_node_ordering=return_node_ordering,
+        )
+
+    # Import graph from FX IR
+    def import_from_fx(
+        self,
+        fx_trace,
+        *inputs,
+        cleanup=False,
+        shape_inference=True,
+        profile=None,
+        warm_up_iters=0,
+        profile_iters=1,
+        return_node_ordering=False,
+        return_fx_graph=False,
+        verbose=False,
+    ):
+        # TODO: we are profiling the model twice: once to measure execution time and once for shape propagation. So we need to somehow combine both ShapeProp into our custom ProfilingInterpreter so that we only profileo once
+        # run profiler
+        if profile:
+            assert isinstance(profile, list) and (
+                "time" in profile or "memory" in profile
+            ), "profile argument should either be None or a list with either 'time' or 'memory' string elements"
+            profiler = fx_profiler.ProfilingInterpreter(
+                fx_trace,
+                profile_time="time" in profile,
+                profile_memory="memory" in profile,
+                warm_up_iters=warm_up_iters,
+                profile_iters=profile_iters,
+            )
+            profiler.run(*inputs)
+            runtime_table = profiler.summary()
+
+        # run shape propagation on fx_traces
+        if shape_inference:
+            assert (
+                len(inputs) > 0
+            ), "Need to have at least one input to run shape inference"
+            ShapeProp(fx_trace).propagate(*inputs)
+        # save fx_trace so that it can be accessed externally
+        self.fx_trace = fx_trace
+        fx_graph = fx_trace.graph
+
+        # create dataflow graph
+        df_graph = dataflow_graph.Graph()
+
+        # load nodes
+        fx2df_node_map = {}
+        for fx_node in fx_graph.nodes:
+            # add node, unless it's the fake output node
+            op_type = (
+                "weight"
+                if fx_node.op == "get_attr"
+                or fx_node.name.startswith("params_")
+                or fx_node.name.startswith("buffers_")
+                else fx_node.op
+            )
+            if op_type != "output":
+                df_node = df_graph.add_node(fx_node.name, op_type)
+                fx2df_node_map[fx_node] = df_node
+
+        # add profiling data to nodes
+        if profile:
+            self._load_profile_data_to_graph(df_graph, runtime_table)
+            profiler = spill_profiler.SpillProfiler(df_graph)
+            spill_times = profiler.benchmark_all()
+            for e, r in spill_times.items():
+                e.time = r
+
+        # define function to get size (in bytes) using recursion as tensor_meta may contain lists or tuples tensor_meta
+        def get_size(tensor_meta):
+            size = 0
+            if isinstance(tensor_meta, torch.fx.passes.shape_prop.TensorMetadata):
+                num_elems = np.prod(tensor_meta.shape)
+                if tensor_meta.dtype == torch.bool:
+                    bits_per_elem = 8
+                elif tensor_meta.dtype.is_floating_point:
+                    bits_per_elem = torch.finfo(tensor_meta.dtype).bits
+                else:
+                    bits_per_elem = torch.iinfo(tensor_meta.dtype).bits
+                num_bits = num_elems * bits_per_elem
+                num_bytes = int(math.ceil(num_bits / 8))
+                size += num_bytes
+            else:
+                assert tensor_meta
+                if tensor_meta is not None:
+                    for t in tensor_meta:
+                        size += get_size(t)
+            return size
+
+        # add edges
+        for fx_node in fx_graph.nodes:
+            size = 0
+            if "tensor_meta" in fx_node.meta:
+                tensor_meta = fx_node.meta["tensor_meta"]
+                size = get_size(tensor_meta)
+            else:
+                # print(f"MISSING META INFO FOR NODE {fx_node} with meta {fx_node.meta}")
+                # We remove getitem nodes, so it's ok if we don't have the shape info there
+                for fanout in fx_node.users.keys():
+                    assert fanout.name == "getitem" or fanout.name.startswith(
+                        "getitem_"
+                    )
+
+            if fx_node not in fx2df_node_map:
+                continue
+            df_node = fx2df_node_map[fx_node]
+            df_sinks = []
+            for fx_sink in fx_node.users.keys():
+                if fx_sink in fx2df_node_map:
+                    df_sinks.append(fx2df_node_map[fx_sink])
+            # for weight tensors, add size to nodes, otherwise add to edge
+            if df_node.op_type == "weight":
+                df_node.size = size
+                size = 0
+
+            if len(df_sinks) > 0:
+                df_graph.add_edge([df_node], df_sinks, size, name=fx_node.name + ":0")
+
+        if verbose:
+            print(
+                f"MODEL STATS: #RAW NODES={len(df_graph.nodes)}, #RAW EDGES={len(df_graph.edges)}"
+            )
+
+        if cleanup:
+            df_graph, unused_weight_size = self._cleanup_dataflow_graph(df_graph)
+            df_graph.unused_weight_size = unused_weight_size
+        else:
+            df_graph.dead_weight_size = 0
+
+        if verbose:
+            print(
+                f"MODEL STATS: #ACTUAL OPERATORS={len(df_graph.nodes)}, #ACTUAL TENSORS={len(df_graph.edges)}"
+            )
+
+        result = [df_graph]
+        if return_node_ordering:
+            order = []
+            for fx_node in fx_graph.nodes:
+                if fx_node not in fx2df_node_map:
+                    continue
+                df_node = fx2df_node_map[fx_node]
+                if df_node.name not in df_graph.nodes:
+                    # print(f"Skipping deleted node {df_node.name}")
+                    continue
+                # print(f"Appending {df_node.name} to ordering")
+                order.append(df_node)
+            result.append(order)
+
+        if return_fx_graph:
+            result.append(fx_trace)
+            result.append(fx2df_node_map)
+
+        if len(result) == 1:
+            return result[0]
+        else:
+            return result
+
+    def _load_profile_data_to_graph(self, df_graph, profiler_table):
+        if "runtimes_sec" in profiler_table.columns:
+            for _, row in profiler_table.iterrows():
+                df_node = df_graph.find_node(row["Op name"])
+                if df_node:
+                    df_node.time = row["runtimes_sec"]
+
+        if (
+            "reserved_bytes.all.current" in profiler_table.columns
+            and "allocated_bytes.all.current" in profiler_table.columns
+        ):
+            # deduce maximum memory fragmentation
+            idx = profiler_table["reserved_bytes.all.current"].idxmax()
+            row = profiler_table.iloc[idx]
+            df_graph.max_mem_fragmentation = (
+                row["reserved_bytes.all.current"] - row["allocated_bytes.all.current"]
+            ) / row["reserved_bytes.all.current"]
+            df_graph.peak_reserved_bytes = row["reserved_bytes.all.current"]
+
+    def _cleanup_dataflow_graph(self, df_graph):
+        unused_weight_size = 0
+        dangling_nodes_to_delete = []
+        getitem_nodes_to_clean = []
+        meta_nodes_to_clean = []
+        weights_to_clean = []
+        in_place_nodes_to_rewire = []
+        for n in df_graph.nodes.values():
+            if (
+                (
+                    n.name.startswith("empty")
+                    or n.name.startswith("buffers")
+                    or n.name.startswith("params")
+                    or n.name.startswith("zeros")
+                    or n.name.startswith("_record_function_enter")
+                )
+                and len(n.fanin) == 0
+                and len(n.fanout) == 0
+            ):
+                dangling_nodes_to_delete.append(n)
+                # These weights/buffers will be loaded by PT, so we need to account for them
+                # to get accuate simulation data
+                unused_weight_size += n.size
+
+            if (
+                (n.name.startswith("buffers") or n.name.startswith("params"))
+                and len(n.fanin) == 0
+                and len(n.fanout) == 1
+            ):
+                deleted_sinks = 0
+                for snk in n.fanout[0].sinks:
+                    if (
+                        (snk.name == "add_" or snk.name.startswith("add__"))
+                        and len(snk.fanin) == 1
+                        and len(snk.fanout) == 0
+                    ):
+                        # Unused counter
+                        deleted_sinks += 1
+                        dangling_nodes_to_delete.append(snk)
+                if deleted_sinks == len(n.fanout[0].sinks):
+                    dangling_nodes_to_delete.append(n)
+                    # These weights/buffers will be loaded by PT, so we need to account for them
+                    # to get accuate simulation data
+                    unused_weight_size += n.size
+
+            elif (n.name == "clone" or n.name.startswith("clone_")) and len(
+                n.fanout
+            ) == 0:
+                dangling_nodes_to_delete.append(n)
+            elif n.name == "getitem" or n.name.startswith("getitem_"):
+                getitem_nodes_to_clean.append(n)
+            elif (
+                n.name == "relu_"
+                or n.name.startswith("relu__")
+                or n.name == "silu_"
+                or n.name.startswith("silu__")
+                or n.name == "hardtanh_"
+                or n.name.startswith("hardtanh__")
+                or n.name == "bernoulli_"
+                or n.name.startswith("bernoulli__")
+                or n.name == "fill_"
+                or n.name.startswith("fill__")
+            ):
+                # In place op
+                meta_nodes_to_clean.append(n)
+            elif (
+                n.name == "div_"
+                or n.name.startswith("div__")
+                and len(n.fanin) == 1
+                and len(n.fanout) == 1
+            ):
+                # In place op
+                meta_nodes_to_clean.append(n)
+            elif (
+                (
+                    n.name == "add_"
+                    or n.name.startswith("add__")
+                    or n.name == "sub_"
+                    or n.name.startswith("sub__")
+                    or n.name == "masked_fill_"
+                    or n.name.startswith("masked_fill__")
+                    or n.name == "copy_"
+                    or n.name.startswith("copy__")
+                )
+                and len(n.fanin) == 2
+                and len(n.fanout) == 1
+            ):
+                in_place_nodes_to_rewire.append(n)
+            elif (
+                (n.name == "t" or n.name.startswith("t_"))
+                or (n.name == "transpose" or n.name.startswith("transpose_"))
+                or (n.name == "permute" or n.name.startswith("permute_"))
+                or (n.name == "_reshape_alias" or n.name.startswith("_reshape_alias_"))
+                or (n.name == "view" or n.name.startswith("view_"))
+                or (n.name == "_unsafe_view" or n.name.startswith("_unsafe_view_"))
+                or (n.name == "view_sym" or n.name.startswith("view_sym_"))
+                or (n.name == "expand" or n.name.startswith("expand_"))
+                or (n.name == "split" or n.name.startswith("split_"))
+                or (n.name == "slice" or n.name.startswith("slice_"))
+                or (n.name == "squeeze" or n.name.startswith("squeeze_"))
+                or (n.name == "unsqueeze" or n.name.startswith("unsqueeze_"))
+                or (n.name == "as_strided" or n.name.startswith("as_strided_"))
+            ):
+                meta_nodes_to_clean.append(n)
+            elif (
+                (
+                    n.name == "native_batch_norm"
+                    or n.name.startswith("native_batch_norm_")
+                )
+                or (
+                    n.name == "native_layer_norm"
+                    or n.name.startswith("native_layer_norm_")
+                )
+                or (n.name == "addmm" or n.name.startswith("addmm_"))
+                or (n.name == "convolution" or n.name.startswith("convolution_"))
+            ):
+                weights_to_clean.append(n)
+
+        for n in dangling_nodes_to_delete:
+            # print(f"deleting dangling node {n.name}")
+            df_graph.delete_node(n)
+
+        for n in getitem_nodes_to_clean:
+            # print(f"deleting getitem node {n.name}")
+            self.bypass_and_delete_getitem_node(df_graph, n)
+
+        for n in meta_nodes_to_clean:
+            # print(f"deleting meta node {n.name}")
+            self.bypass_and_delete_meta_node(df_graph, n)
+
+        for n in in_place_nodes_to_rewire:
+            # print(f"rewiring inplace node {n.name}")
+            self.rewire_in_place_node(df_graph, n)
+
+        for n in weights_to_clean:
+            # print(f"consolidating weights for node {n.name}")
+            self.consolidate_weights(df_graph, n)
+
+        return (df_graph, unused_weight_size)
+
+    def bypass_and_delete_getitem_node(self, df_graph, node):
+        assert len(node.fanin) == 1
+        edge_in = node.fanin[0]
+        assert df_graph.get_size(edge_in) == 0
+        sources = edge_in.sources
+
+        for edge_out in node.fanout:
+            if len(edge_out.sinks) == 0:
+                continue
+            size = df_graph.get_size(edge_out)
+            df_graph.add_edge(
+                sources, edge_out.sinks, size, name=edge_out.name + "_opt"
+            )
+
+        df_graph.delete_node(node)
+
+    def bypass_and_delete_meta_node(self, df_graph, node):
+        assert len(node.fanin) == 1
+        edge_in = node.fanin[0]
+
+        if len(node.fanout) == 1:
+            edge_out = node.fanout[0]
+            edge_in.add_sinks(edge_out.sinks)
+        elif len(node.fanout) > 1:
+            sinks = []
+            for fanout in node.fanout:
+                sinks += fanout.sinks
+            edge_in.add_sinks(sinks)
+
+        df_graph.delete_node(node)
+
+    def rewire_in_place_node(self, df_graph, node):
+        # If there are control dependencies, make sure they come after regular inputs
+        assert len(node.fanin) >= 2
+        for i in range(2):
+            assert node.fanin[i].size > 0
+        for i in range(2, len(node.fanin)):
+            assert node.fanin[i].size == 0
+        assert len(node.fanout) == 1
+
+        # The first input will be modified in place and returned as output.
+        assert node.fanin[0].size == node.fanout[0].size
+        node.fanout[0].size = 0
+        for snk in node.fanout[0].sinks:
+            # print(f"Processing snk {snk}")
+            assert len(snk.fanin) > 0
+            for i in range(0, len(snk.fanin)):
+                # print(f"    Checkin fanin {snk.fanin[i]} againt {node.fanout[0]}", flush=True)
+                if id(snk.fanin[i]) == id(node.fanout[0]):
+                    snk.fanin[i] = node.fanin[0]
+                    node.fanin[0].sinks.append(snk)
+                    snk.fanin.append(node.fanout[0])
+                    # print(f"   Updated sink node {snk}")
+                    break
+
+    def consolidate_weights(self, df_graph, node):
+        weights_to_merge = []
+        for f in node.fanin:
+            if not f.is_stateful():
+                continue
+            weights_to_merge.extend(f.sources)
+
+        if len(weights_to_merge) <= 1:
+            # print(f"no weight to merge for node : {node}")
+            return
+
+        ref_sinks = set()
+        assert len(weights_to_merge[0].fanout) == 1
+        for s in weights_to_merge[0].fanout[0].sinks:
+            ref_sinks.add(s)
+
+        # Merge the weight nodes
+        sinks_to_merge = []
+        for i in range(1, len(weights_to_merge)):
+            assert len(weights_to_merge[i].fanout) == 1
+            for s in weights_to_merge[i].fanout[0].sinks:
+                if s not in ref_sinks:
+                    weights_to_merge[0].fanout[0].add_sink(s)
+                    sinks_to_merge.append(s)
+
+        for i in range(1, len(weights_to_merge)):
+            weights_to_merge[0].size += weights_to_merge[i].size
+            df_graph.delete_node(weights_to_merge[i])
+
+        nodes_to_delete = []
+        for s in sinks_to_merge:
+            # Look for a similar operator in ref_sinks
+            # print(f"Looking for merge candidate for {s}")
+            for r in ref_sinks:
+                if r.op_type != s.op_type:
+                    continue
+                if len(r.fanin) != len(s.fanin):
+                    continue
+                valid_candidate = True
+                # print(f"  Checking candidate {r}")
+                edges_to_merge = []
+                for f in s.fanin:
+                    if f in r.fanin:
+                        # print(f"    {f} in candidate fanin set")
+                        continue
+                    found_match = False
+                    for fr in r.fanin:
+                        if fr.sources == f.sources:
+                            # print("    Sources do match")
+                            edges_to_merge.append((f, fr))
+                            found_match = True
+                            break
+                        # else:
+                        # print(
+                        #    f"    sources don't match: {fr.sources} vs {f.sources}"
+                        # )
+
+                    if not found_match:
+                        # print(f"    Found invalid fanin {f}")
+                        valid_candidate = False
+                        break
+
+                if valid_candidate:
+                    # print(f"  Merging {s} with {r}")
+                    for f, fr in edges_to_merge:
+                        fr.size += f.size
+                    nodes_to_delete.append(s)
+                    break
+
+        for n in nodes_to_delete:
+            df_graph.delete_node(n)
+
+        edges_to_merge = []
+        for i in range(len(node.fanout)):
+            for j in range(i + 1, len(node.fanout)):
+                fi = node.fanout[i]
+                fj = node.fanout[j]
+                if fi.sinks == fj.sinks:
+                    edges_to_merge.append((fi, fj))
+
+        # The code below isn't right if there's more than one pair of edges to merge. Fortunately this doesn't happen in practice.
+        assert len(edges_to_merge) <= 1
+        for f, fo in edges_to_merge:
+            f.size += fo.size
+            df_graph.delete_edge(fo)

--- a/olla/training_graph_optimizer.py
+++ b/olla/training_graph_optimizer.py
@@ -1,0 +1,1308 @@
+import itertools
+import math
+import sys
+from collections import defaultdict, OrderedDict
+
+import intervaltree
+from olla import dataflow_graph, ilp_solver, utils
+
+
+class Scheduler:
+    def __init__(
+        self,
+        graph,
+        timeout_s=None,
+        rel_stop=None,
+        solver="GUROBI",
+        timestep_factor=1.0,
+        print_relaxation=False,
+    ):
+        self.graph = graph
+        self.timeout = timeout_s
+        self.rel_stop = rel_stop
+        self.solver = solver
+        self.timestep_factor = timestep_factor
+        self.print_relaxation = print_relaxation
+
+        # Skip the weights when computing the number of timesteps needed: since we want to
+        # spill the weight while computing, we don't need to reserve timesteps for these
+        # spills
+        self.num_nodes = 0
+        for n in graph.nodes.values():
+            if not n.is_stateful():
+                self.num_nodes += 1
+
+        self.longest_path_length = graph.longest_path_length()
+
+    # Compute the earliest time a node can be scheduled. It's in the range
+    # [1, m], where m is the number of nodes in the graph.
+    def ComputeASAPSchedule(self, schedule_constraints):
+        timings = {}
+        for vertex in self.graph.nodes.values():
+            self._ComputeASAPSchedule(vertex, timings, schedule_constraints)
+        return timings
+
+    def _ComputeASAPSchedule(self, vertex, timings, schedule_constraints):
+        if vertex in timings:
+            # Already visited
+            return timings[vertex]
+        time = 1
+        for e in vertex.fanin:
+            source = e.source
+            t = self._ComputeASAPSchedule(source, timings, schedule_constraints)
+            time = max(t + 1, time)
+
+        if vertex in schedule_constraints:
+            if time > schedule_constraints[vertex]:
+                raise ValueError(
+                    "Infeasible user schedule specified for node %s: requested %d, min_feasible %d"
+                    % (str(vertex), schedule_constraints[vertex], time)
+                )
+            time = schedule_constraints[vertex]
+
+        timings[vertex] = time
+
+        return time
+
+    # Compute the latest time a node can be scheduled. It's in the range
+    # [1, m], where m is the number of nodes in the graph.
+    def ComputeALAPSchedule(self, schedule_constraints, max_timesteps):
+        timings = {}
+        for vertex in self.graph.nodes.values():
+            self._ComputeALAPSchedule(
+                vertex, timings, schedule_constraints, max_timesteps
+            )
+        return timings
+
+    def _ComputeALAPSchedule(
+        self, vertex, timings, schedule_constraints, max_timesteps
+    ):
+        if vertex in timings:
+            # Already visited
+            return timings[vertex]
+        time = max_timesteps
+        for e in vertex.fanout:
+            for sink in e.sinks:
+                t = self._ComputeALAPSchedule(
+                    sink, timings, schedule_constraints, max_timesteps
+                )
+                time = min(t - 1, time)
+
+        if vertex in schedule_constraints:
+            if time < schedule_constraints[vertex]:
+                raise ValueError(
+                    "Infeasible user schedule specified for node %s" % str(vertex)
+                )
+            time = schedule_constraints[vertex]
+
+        timings[vertex] = time
+        return time
+
+    def ComputeMakespans(self, asap, alap):
+        makespan = {}
+        for n in self.graph.nodes.values():
+            lb = asap[n]
+            for e in n.fanout:
+                ub = alap[n]
+                for snk in e.sinks:
+                    assert alap[snk] > alap[n]
+                    ub = max(ub, alap[snk])
+                makespan[e] = (lb, ub)
+                # print(e.name + "[" + str(lb) + ", " + str(up) + "]")
+        return makespan
+
+    def _GCD(self, values):
+        if len(values) == 0:
+            return 1
+        if len(values) == 1:
+            return values[0]
+        elif len(values) == 2:
+            return math.gcd(values[0], values[1])
+        else:
+            middle = len(values) // 2
+            return math.gcd(self._GCD(values[:middle]), self._GCD(values[middle:]))
+
+    class TimeStepsForNode:
+        def __init__(self, node, spans, startoffset=0):
+            asap = spans[1]
+            alap = spans[2]
+            lb = asap[node]
+            ub = alap[node]
+            assert not node.is_stateful()
+            self.iter = iter(range(lb + startoffset, ub + 1))
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return self.iter.__next__()
+
+    class TimeStepsForEdge:
+        def __init__(self, edge, spans, startoffset=0):
+            lb, ub = spans[0][edge]
+
+            intervals = intervaltree.IntervalTree()
+            for snk in edge.sinks:
+                if snk.op_type == "stateful_node_sink":
+                    continue
+                new_lb = spans[1][snk]
+                new_lb = max(1, new_lb - 1)
+                new_ub = spans[2][snk]
+                intervals.add(intervaltree.Interval(new_lb, new_ub + 1))
+
+            if not edge.is_stateful():
+                src = edge.source
+                new_lb = spans[1][src]
+                new_ub = spans[2][src]
+                intervals.add(intervaltree.Interval(new_lb, new_ub + 1))
+            else:
+                intervals.add(intervaltree.Interval(lb, lb + 1))
+                intervals.add(intervaltree.Interval(ub, ub + 1))
+
+            ts = []
+            intervals.merge_overlaps()
+            for i in intervals:
+                ts += list(range(i.begin, i.end))
+
+            ts = sorted(ts)
+            self.iter = iter(ts[startoffset:])
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return self.iter.__next__()
+
+    class TimeStepsForFanin:
+        def __init__(self, node, spans):
+            if len(node.fanin) == 0:
+                self.iter = iter([])
+                return
+            timesteps = set(Scheduler.TimeStepsForEdge(node.fanin[0], spans))
+            for i in range(1, len(node.fanin)):
+                timesteps &= set(Scheduler.TimeStepsForEdge(node.fanin[i], spans))
+
+            timesteps = sorted(timesteps)
+            self.iter = iter(timesteps)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return self.iter.__next__()
+
+    class DensePreserveVarsMap:
+        def __init__(self, sparse_map):
+            local_map = {}
+            maxi = 0
+            mini = math.inf
+            for i in sparse_map:
+                if i > maxi:
+                    maxi = i
+                if i < mini:
+                    mini = i
+            for i in range(maxi, mini - 1, -1):
+                assert i >= mini
+                assert i <= maxi
+                if i not in sparse_map:
+                    local_map[i] = local_map[i + 1]
+                else:
+                    local_map[i] = sparse_map[i]
+            self.local_map = OrderedDict(sorted(local_map.items()))
+
+        def __getitem__(self, index):
+            return self.local_map[index]
+
+        def items(self):
+            return self.local_map.items()
+
+    class DenseGenerateOrFetchVarsMap:
+        def __init__(self, sparse_map):
+            self.sparse_map = sparse_map
+
+        def __getitem__(self, index):
+            if index not in self.sparse_map:
+                return 0
+            return self.sparse_map[index]
+
+    def ComputeMinimumMemoryRequired(self):
+        min_memory_requirement = 0
+        bottleneck_node = None
+        for n in self.graph.nodes.values():
+            mem_needed = 0
+            for e in n.fanin:
+                mem_needed += e.size
+            for e in n.fanout:
+                mem_needed += e.size
+            if mem_needed > min_memory_requirement:
+                min_memory_requirement = mem_needed
+                bottleneck_node = n
+        return (min_memory_requirement, bottleneck_node)
+
+    def ComputeMaximumMemoryRequired(self):
+        max_memory_requirement = 0
+        for e in self.graph.edges.values():
+            max_memory_requirement += e.size
+        return max_memory_requirement
+
+    # Compute the optimal memory schedule. Returns the (summary, schedule)
+    # pair, where summary is a map containing the following entries:
+    #   peak_mem_usage: maximum total size of the tensors at any time
+    #   total_data_swapped: total amount of data spilled and restored
+    #   required_memory: total amount of memory needed to run the model. This
+    #   corresponds to the peak_memory_usage plus space wasted due to
+    #   fragmentation
+    def ComputeOptimalSchedule(
+        self,
+        mem_limit=sys.maxsize,
+        allow_rematerialization=False,
+        allow_swaps=False,
+        account_for_fragmentation=False,
+        defrag=False,
+        user_schedule=None,
+        max_spills=None,
+    ):
+        # Compute the minimum amount of memory required to run the graph.
+        min_memory_requirement, bottleneck_node = self.ComputeMinimumMemoryRequired()
+        min_memory_requirement_acurate = False
+        if min_memory_requirement > mem_limit:
+            raise ValueError(
+                "The graph requires at least %d bytes to run due to node %s (limit: %d)"
+                % (min_memory_requirement, bottleneck_node.name, mem_limit)
+            )
+
+        schedule_constraints = {}
+        if user_schedule is not None:
+            for n, ts in user_schedule.items():
+                if ts <= 0:
+                    raise ValueError(
+                        "Negative or null timestep specified for node %s" % str(n)
+                    )
+                if isinstance(n, str):
+                    name = n
+                else:
+                    assert isinstance(n, dataflow_graph.Node)
+                    name = n.name
+                if name not in self.graph.nodes:
+                    print(
+                        "Invalid schedule: node "
+                        + name
+                        + " does not exist in the graph"
+                    )
+                    continue
+                n = self.graph.nodes[name]
+                schedule_constraints[n] = ts
+
+        num_timesteps = self.num_nodes
+        if not allow_rematerialization and not allow_swaps:
+            num_timesteps = min(
+                int(math.ceil(self.longest_path_length * 1.01)), num_timesteps
+            )
+        num_timesteps = int(num_timesteps * self.timestep_factor)
+
+        if self.timestep_factor < 1 and self.longest_path_length > num_timesteps:
+            # Make sure we have enough timesteps to run the longest path
+            print(
+                f"Adjusting num_timesteps to {self.longest_path_length} to ensure there are enough steps to run the longest path"
+            )
+            num_timesteps = self.longest_path_length
+
+        # Compute the range of times during which each tensor can be alive, based
+        # purely on precedence constraints.
+        asap = self.ComputeASAPSchedule(schedule_constraints)
+        alap = self.ComputeALAPSchedule(schedule_constraints, num_timesteps)
+        makespan = self.ComputeMakespans(asap, alap)
+
+        spans = (makespan, asap, alap)
+
+        # GCD
+        tensor_sizes = [t.size for t in self.graph.edges.values() if t.size > 0]
+        gcd = self._GCD(tensor_sizes)
+        max_address = min(self.ComputeMaximumMemoryRequired(), mem_limit) // gcd
+
+        int_feas_tol = None
+        if defrag or account_for_fragmentation:
+            int_feas_tol = min(1e-5, 1.0 / max_address)
+            int_feas_tol = max(1e-9, int_feas_tol)
+            if 1.0 / max_address > 1e-5:
+                print(f"Tightened IntFeasTol to {int_feas_tol}")
+
+        solver = ilp_solver.ILPSolver(
+            timeout_s=self.timeout,
+            rel_stop=self.rel_stop,
+            solver=self.solver,
+            int_feas_tol=int_feas_tol,
+            extra_params={"MIPFocus": 1},
+        )
+
+        # Create 2 new variable for each tensor and timestep: generate and preserve
+        generate_vars = defaultdict(lambda: {})
+        preserve_vars = defaultdict(lambda: {})
+        fetch_vars = defaultdict(lambda: {})
+
+        for e in self.graph.edges.values():
+            lb, ub = makespan[e]
+            for t in self.TimeStepsForEdge(e, spans):
+                v = solver.create_binary_var(e.name + "_generate_ts" + str(t))
+                generate_vars[e][t] = v
+                v = solver.create_binary_var(e.name + "_preserve_ts" + str(t))
+                preserve_vars[e][t] = v
+                v = solver.create_binary_var(e.name + "_fetch_ts" + str(t))
+                fetch_vars[e][t] = v
+
+            if e.source in schedule_constraints:
+                ts = schedule_constraints[e.source]
+                assert ts >= lb
+                assert ts <= ub
+                for t in self.TimeStepsForEdge(e, spans):
+                    if t != ts and not allow_rematerialization:
+                        solver.add_constraint(
+                            generate_vars[e][t] == 0,
+                            name=f"{utils.get_linenumber()}_{e.name}_generate_var@{t}",
+                        )
+                    else:
+                        solver.add_constraint(
+                            generate_vars[e][t] == 1,
+                            name=f"{utils.get_linenumber()}_{e.name}_generate_var@{t}",
+                        )
+
+            for snk in e.sinks:
+                if snk in schedule_constraints:
+                    ts = schedule_constraints[snk]
+                    assert ts >= lb
+                    assert ts <= ub
+                    solver.add_constraint(
+                        preserve_vars[e][ts] + fetch_vars[e][ts] == 1,
+                        name=f"{utils.get_linenumber()}_{e.name}_preserve_or_fetch_var@{ts}",
+                    )
+
+        spilling_allowed = allow_swaps and (max_spills is None or max_spills > 0)
+
+        # Add correctness constraints: we can't preserve data unless it's been
+        # generated or preserved at the previous timestep. Also it doesn't make
+        # sense to preserve and compute same data at the same timestep
+        for e in self.graph.edges.values():
+            prev = self.TimeStepsForEdge(e, spans)
+            cur = self.TimeStepsForEdge(e, spans, startoffset=1)
+            for t in cur:
+                p = prev.__next__()
+
+                solver.add_constraint(
+                    preserve_vars[e][t]
+                    <= preserve_vars[e][p] + generate_vars[e][p] + fetch_vars[e][p],
+                    name=f"{utils.get_linenumber()}_{e.name}_precedence@{t}",
+                )
+                solver.add_constraint(
+                    preserve_vars[e][t] + generate_vars[e][t] + fetch_vars[e][t] <= 1,
+                    name=f"{utils.get_linenumber()}_{e.name}_at_most_one@{t}",
+                )
+
+            # Purely to help the solver. Todo: improve the encoding to avoid
+            # creating these variables in the first place
+            lb, _ = makespan[e]
+            solver.add_constraint(
+                preserve_vars[e][lb] == 0,
+                name=f"{utils.get_linenumber()}_{e.name}_preserve_var@{lb}",
+            )
+            solver.add_constraint(
+                fetch_vars[e][lb] == 0,
+                name=f"{utils.get_linenumber()}_{e.name}_fetch_var@{lb}",
+            )
+            if lb + 1 in fetch_vars[e]:
+                solver.add_constraint(
+                    fetch_vars[e][lb + 1] == 0,
+                    name=f"{utils.get_linenumber()}_{e.name}_fetch_var@{lb+1}",
+                )
+            for t in self.TimeStepsForEdge(e, spans):
+                if t > alap[e.source]:
+                    # if not allow_rematerialization or e.is_stateful():
+                    solver.add_constraint(
+                        generate_vars[e][t] == 0,
+                        name=f"{utils.get_linenumber()}_{e.name}_generate_var_past_alap@{t}",
+                    )
+
+            # Purely to help the solver: there is no need to swap the control edges.
+            if e.size == 0 or not spilling_allowed:
+                for t in self.TimeStepsForEdge(e, spans):
+                    solver.add_constraint(
+                        fetch_vars[e][t] == 0,
+                        name=f"{utils.get_linenumber()}_{e.name}_fetch_var@{t}",
+                    )
+
+            # Control edges are always available once they've been triggered.
+            if e.size == 0:
+                prev = self.TimeStepsForEdge(e, spans)
+                for t in self.TimeStepsForEdge(e, spans, startoffset=1):
+                    p = prev.__next__()
+                    if t <= alap[e.source]:
+                        solver.add_constraint(
+                            preserve_vars[e][t]
+                            >= preserve_vars[e][p] + generate_vars[e][p],
+                            name=f"{utils.get_linenumber()}_{e.name}_ctrl_edge@{t}",
+                        )
+                    else:
+                        # The source node has been run at this point.
+                        solver.add_constraint(
+                            preserve_vars[e][t] == 1,
+                            name=f"{utils.get_linenumber()}_{e.name}_preserve_var@{t}",
+                        )
+
+        # Add precedence constraints: we need all the nodes inputs to be
+        # available in memory at time t in order to evaluate the node.
+        # We also ensure that all the fanouts of a node are generated at the
+        # same time. This is only an optimization, since the objective of
+        # minimizing the number of computation would take care of that on its on.
+        for n in self.graph.nodes.values():
+            if len(n.fanout) > 1:
+                for i in range(1, len(n.fanout)):
+                    for t in self.TimeStepsForNode(n, spans):
+                        solver.add_constraint(
+                            generate_vars[n.fanout[0]][t]
+                            == generate_vars[n.fanout[i]][t],
+                            name=f"{utils.get_linenumber()}_{n.name}_all_fanouts_generated@{t}",
+                        )
+
+            for snk in n.fanout:
+                for src in n.fanin:
+                    # Add precedence constraints
+                    for t in self.TimeStepsForNode(n, spans):
+                        solver.add_constraint(
+                            generate_vars[snk][t]
+                            <= preserve_vars[src][t] + fetch_vars[src][t],
+                            name=f"{utils.get_linenumber()}_{snk.name}_{src.name}_precedence@{t}",
+                        )
+
+        # We can't swap the data back in unless it's already been generated
+        # (and implicitely swapped out instead of being simply discarded).
+        for e in self.graph.edges.values():
+            if e.size == 0:
+                continue
+            cur = self.TimeStepsForEdge(e, spans)
+            try:
+                p = cur.__next__()
+                previously_generated = generate_vars[e][p]
+                for t in cur:
+                    if t > alap[e.source]:
+                        break
+                    solver.add_constraint(
+                        fetch_vars[e][t] <= previously_generated,
+                        name=f"{utils.get_linenumber()}_{e.name}_fetchable@{t}",
+                    )
+                    previously_generated += generate_vars[e][t]
+                    p = t
+            except StopIteration:
+                pass
+
+        # Force the generation of each tensor at least once (or exactly once if
+        # rematerialization is not allowed)
+        for e, ts in generate_vars.items():
+            s = 0
+            for v in ts.values():
+                s += v
+            if (
+                allow_rematerialization
+                and not e.is_stateful()
+                and e.size > 0
+                and e.source.time is not None
+            ):
+                solver.add_constraint(
+                    1 <= s,
+                    name=f"{utils.get_linenumber()}_{e.name}_materialized_at_least_once",
+                )
+            else:
+                solver.add_constraint(
+                    1 == s,
+                    name=f"{utils.get_linenumber()}_{e.name}_materialized_once",
+                )
+
+        # A node needs to consume all its inputs at the same timestep. Handle
+        # the case where the node has no fanout below. The case where the node
+        # has fanout is already handled.
+        for n in self.graph.nodes.values():
+            if len(n.fanout) > 0:
+                continue
+            if len(n.fanin) <= 1:
+                continue
+
+            # We need at least one timestep during which all the inputs are live at the same time
+            sum_of_all_live = 0
+            for t in self.TimeStepsForFanin(n, spans):
+                if t > alap[n]:
+                    break
+                all_live = solver.create_binary_var(
+                    "fanin_of_" + n.name + "_live_at_ts" + str(t)
+                )
+
+                for f in n.fanin:
+                    solver.add_constraint(
+                        all_live <= preserve_vars[f][t] + fetch_vars[f][t],
+                        name=f"{utils.get_linenumber()}_fanin_of_{n.name}_dead_due_to_{f.name}@{t}",
+                    )
+                sum_of_all_live += all_live
+            solver.add_constraint(
+                sum_of_all_live >= 1,
+                name=f"{utils.get_linenumber()}_fanin_of_{n.name}_live_at_one_ts",
+            )
+
+        # Ensure that weights are preserved in memory during the whole
+        # computation if spilling is disabled.
+        if not spilling_allowed:
+            for e in self.graph.edges.values():
+                if not e.is_stateful():
+                    continue
+                first_timestep = True
+                for t in self.TimeStepsForEdge(e, spans):
+                    if first_timestep:
+                        solver.add_constraint(
+                            generate_vars[e][t] == 1,
+                            name=f"{utils.get_linenumber()}_cannot_spill_{e.name}_@{t}",
+                        )
+                        solver.add_constraint(
+                            preserve_vars[e][t] == 0,
+                            name=f"{utils.get_linenumber()}_cannot_spill_{e.name}_@{t}",
+                        )
+                    else:
+                        solver.add_constraint(
+                            generate_vars[e][t] == 0,
+                            name=f"{utils.get_linenumber()}_cannot_spill_{e.name}_@{t}",
+                        )
+                        solver.add_constraint(
+                            preserve_vars[e][t] == 1,
+                            name=f"{utils.get_linenumber()}_cannot_spill_{e.name}_@{t}",
+                        )
+                    first_timestep = False
+
+        # Ensure that activations are preserved in memory once they've been generated
+        # and until their last consumer runs
+        if not spilling_allowed:
+            for e in self.graph.edges.values():
+                if e.is_stateful():
+                    continue
+                first = alap[e.source] + 1
+                last = 0
+                for v in e.sinks:
+                    last = max(last, asap[v])
+                for ts in self.TimeStepsForEdge(e, spans):
+                    if ts < first or ts > last:
+                        continue
+                    solver.add_constraint(
+                        preserve_vars[e][ts] == 1,
+                        name=f"{utils.get_linenumber()}_{e.name}_must_be_preserved_@{t}",
+                    )
+
+        # Memory usage at each timestep
+        mem_at_timestep = defaultdict(lambda: 0)
+        persistent_weight_size = 0
+        for e in self.graph.edges.values():
+            if e.size == 0:
+                continue
+            if (not spilling_allowed) and e.is_stateful():
+                # This edge always reside in memory. We don't need to track it separately
+                persistent_weight_size += e.size
+                continue
+
+            for t, v in self.DensePreserveVarsMap(preserve_vars[e]).items():
+                mem_at_timestep[t] += v * (e.size // gcd)
+
+            for t, v in generate_vars[e].items():
+                mem_at_timestep[t] += v * (e.size // gcd)
+
+            for t, v in fetch_vars[e].items():
+                mem_at_timestep[t] += v * (e.size // gcd)
+
+        if max_spills is None:
+            # We need to fit withing the memory budget at each timestep
+            # TODO: check if leveraging Bradley, Hammer, and Wolsey to optimize these
+            # constraints helps the solver
+            liveness = defaultdict(lambda: [])
+            for e in self.graph.edges.values():
+                if e.size == 0:
+                    continue
+                lb, ub = makespan[e]
+                for ts in range(lb, ub + 1):
+                    liveness[ts].append(e)
+            for ts, mem_usage in mem_at_timestep.items():
+                max_mem = 0
+                for e in liveness[ts]:
+                    max_mem += e.size
+                if max_mem < mem_limit:
+                    # No point in adding a constraint
+                    continue
+                max_mem -= persistent_weight_size
+                solver.add_constraint(
+                    mem_usage <= (mem_limit - persistent_weight_size) // gcd,
+                    name=f"{utils.get_linenumber()}_mem_usage_less_than_{mem_limit}@{ts}",
+                )
+
+        elif max_spills > 0:
+            # We need to ensure that we don't exceed our total spill budget
+            spills_per_tensor = defaultdict(lambda: 0)
+            for e, ts in fetch_vars.items():
+                if e.size > 0:
+                    for _, v in ts.items():
+                        spills_per_tensor[e] += v
+
+            total_spills = 0
+            for e, s in spills_per_tensor.items():
+                is_spilled = solver.create_binary_var("is_" + e.name + "_spilled")
+                solver.add_constraint(is_spilled <= s)
+                lb, ub = makespan[e]
+                max_spills = min(len(e.sinks), ub - lb + 1)
+                solver.add_constraint(is_spilled * max_spills >= s)
+                total_spills += (s + is_spilled) * (e.size // gcd)
+
+            for n in self.graph.nodes.values():
+                if n.op_type != "stateful_node_sink":
+                    continue
+                for edge in n.fanin:
+                    missing_during_startup = 1 - generate_vars[edge][1]
+                    missing_during_cleanup = 1 - preserve_vars[edge][num_timesteps]
+                    extra_spill = solver.create_binary_var(edge.name + "_spilled")
+                    solver.add_constraint(extra_spill >= missing_during_startup)
+                    solver.add_constraint(extra_spill >= missing_during_cleanup)
+                    # Unnecessary and slows us down
+                    # solver.add_constraint(
+                    #    extra_spill <= missing_during_startup + missing_during_cleanup
+                    # )
+                    factor = 1 if edge.source.read_only else 2
+                    total_spills += extra_spill * (edge.size * factor // gcd)
+
+            # TODO: check if leveraging Bradley, Hammer, and Wolsey to optimize these
+            # constraints helps the solver
+            solver.add_constraint(total_spills <= max_spills // gcd)
+
+        if account_for_fragmentation and not defrag:
+            max_address = (
+                min(self.ComputeMaximumMemoryRequired(), mem_limit)
+                - persistent_weight_size
+            ) // gcd
+
+            # Create a new variable for each tensor that tracks the base address
+            # of the tensor. If the tensor is of size 0, we force its address to be
+            # 0 to help the solver
+            addresses = OrderedDict()
+            for tensor in self.graph.edges.values():
+                if tensor.size > 0 and (not tensor.is_stateful() or spilling_allowed):
+                    v = solver.create_integer_var(
+                        tensor.name,
+                        lower_bound=0,
+                        upper_bound=max_address - tensor.size // gcd,
+                    )
+                    addresses[tensor] = v
+
+            # Manually assign some of the addresses when possible
+            fixed_locations = {}
+            manual_allocation_possible = False
+            if not spilling_allowed:
+                manual_allocation_possible = True
+                for n in self.graph.nodes.values():
+                    if n.is_stateful():
+                        continue
+                    if n not in user_schedule:
+                        manual_allocation_possible = False
+                        break
+
+            max_mem = 0
+
+            if manual_allocation_possible:
+                print("STARTING TENSOR ASSIGNMENT")
+                min_start = 0
+                max_end = num_timesteps
+                base_address = 0
+                processed = set()
+                mem_used = intervaltree.IntervalTree()
+                while max_end > min_start:
+                    max_duration = 0
+                    next_step = None
+                    for tensor, span in makespan.items():
+                        if tensor.size == 0 or (
+                            tensor.is_stateful() and not spilling_allowed
+                        ):
+                            continue
+                        if span[0] < min_start:
+                            continue
+                        if span[1] > max_end:
+                            continue
+                        if tensor in processed:
+                            continue
+                        duration = span[1] - span[0]
+                        if duration > max_duration:
+                            max_duration = duration
+                            next_step = tensor
+                    if not next_step:
+                        break
+                    solver.add_constraint(
+                        addresses[next_step] == base_address,
+                        name=f"{utils.get_linenumber()}_force_{next_step.name}_at_{base_address}",
+                    )
+                    fixed_locations[next_step] = base_address
+                    print(
+                        f"   TENSOR {next_step.name}, min start {min_start}, max_end {max_end} size {next_step.size} located at {base_address}"
+                    )
+
+                    base_address += next_step.size // gcd
+                    min_start = makespan[next_step][0]
+                    max_end = makespan[next_step][1]
+                    processed.add(next_step)
+                    mem_used[min_start : max_end + 1] = base_address
+
+                max_mem = base_address
+                for t, a in addresses.items():
+                    if t in fixed_locations:
+                        a.Start = fixed_locations[t]
+                    else:
+                        span = makespan[t]
+                        max_address_used = 0
+                        # print(f"Querying intervaltree {span[0]} {span[1]+1}")
+                        for interval in mem_used.overlap(span[0], span[1] + 1):
+                            # print(f"address {interval.data} used")
+                            max_address_used = max(max_address_used, interval.data)
+                        a.Start = max_address_used
+                        # print(f"Adding gen address to intervaltree {span[0]} {span[1]}")
+                        mem_used[span[0] : span[1] + 1] = (
+                            max_address_used + t.size // gcd
+                        )
+                        max_mem = max(max_mem, max_address_used + t.size // gcd)
+
+                for t, a in addresses.items():
+                    if t not in fixed_locations:
+                        solver.add_constraint(
+                            a <= max_mem - t.size // gcd,
+                            name=f"{utils.get_linenumber()}_tighten_max_address_for_{t.name}",
+                        )
+
+                # Refine the minimum memory requirement
+                min_mem_per_span = intervaltree.IntervalTree()
+                for t in addresses.keys():
+                    span = makespan[t]
+                    min_mem_per_span[span[0] : span[1] + 1] = t
+                min_mem_required = 0
+                for t in range(1, num_timesteps + 1):
+                    # print(f"LOOKING AT TIMESTEP {t}")
+                    mem_at_t = 0
+                    for interval in min_mem_per_span[t]:
+                        t = interval.data
+                        # print(f"tensor {t.name} used. span was [{makespan[t][0]}, {makespan[t][1]}]")
+                        mem_at_t += t.size
+                    min_mem_required = max(min_mem_required, mem_at_t)
+                min_memory_requirement = min_mem_required
+                min_memory_requirement_acurate = True
+                print("DONE WITH TENSOR ASSIGNMENT")
+
+            processed = set()
+            for t1, span1 in makespan.items():
+                if t1.size == 0 or (t1.is_stateful() and (not spilling_allowed)):
+                    continue
+                # Help the solver by providing upper bounds for all the addresses
+                # solver.add_constraint(addresses[t1] + t1.size // gcd <= max_address)
+                for t2, span2 in makespan.items():
+                    if t2.size == 0 or (t2.is_stateful() and (not spilling_allowed)):
+                        continue
+                    if t1 is t2 or (t2, t1) in processed:
+                        continue
+                    processed.add((t1, t2))
+                    if (
+                        span1[1] < span2[0]
+                        or span1[0] > span2[1]
+                        or not self.graph.can_overlap_in_time(t1, t2)
+                    ):
+                        # print(t1.name + " and " + t2.name + "CANNOT OVERLAP")
+                        continue
+
+                    if t1 in fixed_locations and t2 in fixed_locations:
+                        continue
+
+                    live_together = self.graph.are_connected_by_node(t1, t2)
+                    if not live_together and not spilling_allowed:
+                        if alap[t1.source] <= asap[t2.source]:
+                            for snk in t1.sinks:
+                                if asap[snk] >= alap[t2.source]:
+                                    live_together = True
+                        elif alap[t2.source] <= asap[t1.source]:
+                            for snk in t2.sinks:
+                                if asap[snk] >= alap[t1.source]:
+                                    live_together = True
+
+                    if live_together:
+                        if t1 in fixed_locations:
+                            solver.add_constraint(
+                                addresses[t2] >= fixed_locations[t1] + t1.size // gcd,
+                                name=f"{utils.get_linenumber()}_force_{t1.name}_below_{t2.name}",
+                            )
+
+                        elif t2 in fixed_locations:
+                            solver.add_constraint(
+                                addresses[t1] >= fixed_locations[t2] + t2.size // gcd,
+                                name=f"{utils.get_linenumber()}_force_{t1.name}_above_{t2.name}",
+                            )
+
+                        else:
+                            v = solver.create_binary_var(
+                                name=f"{utils.get_linenumber()}_{t1.name}_below_{t2.name}"
+                            )
+                            solver.add_constraint(
+                                addresses[t1] + t1.size // gcd - addresses[t2]
+                                <= (1 - v) * max_address,
+                                name=f"{utils.get_linenumber()}_force_{t1.name}_below_{t2.name}",
+                            )
+                            solver.add_constraint(
+                                addresses[t1] - addresses[t2] - t2.size // gcd
+                                >= -v * max_address,
+                                name=f"{utils.get_linenumber()}_force_{t1.name}_above_{t2.name}",
+                            )
+
+                    elif span1[1] >= span2[0] and span1[0] <= span2[1]:
+                        # The spans may overlap: if they do, one of these 2 constraints must hold:
+                        # variables[t1] + t1.size <= variables[t2]
+                        # variables[t1] >= variables[t2] + t2.size
+                        v1 = solver.create_binary_var(t1.name + "_" + t2.name + "_v1")
+                        solver.add_constraint(
+                            addresses[t1] + t1.size // gcd - addresses[t2]
+                            <= (1 - v1) * max_address,
+                            name=f"{utils.get_linenumber()}_{t1.name}_below_{t2.name}",
+                        )
+
+                        v2 = solver.create_binary_var(t1.name + "_" + t2.name + "_v2")
+                        solver.add_constraint(
+                            addresses[t1] - addresses[t2] - t2.size // gcd
+                            >= (v2 - 1) * max_address,
+                            name=f"{utils.get_linenumber()}_{t1.name}_above_{t2.name}",
+                        )
+
+                        if t1 in fixed_locations:
+                            solver.add_constraint(v1 == 1)
+                        elif t2 in fixed_locations:
+                            solver.add_constraint(v2 == 1)
+                        else:
+                            # Let's check if that helps
+                            solver.add_constraint(v1 + v2 <= 1)
+
+                        # check if they actually do overlap
+                        generate_t1 = self.DenseGenerateOrFetchVarsMap(
+                            generate_vars[t1]
+                        )
+                        preserve_t1 = self.DensePreserveVarsMap(preserve_vars[t1])
+                        fetch_t1 = self.DenseGenerateOrFetchVarsMap(fetch_vars[t1])
+                        generate_t2 = self.DenseGenerateOrFetchVarsMap(
+                            generate_vars[t2]
+                        )
+                        preserve_t2 = self.DensePreserveVarsMap(preserve_vars[t2])
+                        fetch_t2 = self.DenseGenerateOrFetchVarsMap(fetch_vars[t2])
+
+                        for ts in range(
+                            max(span1[0], span2[0]), min(span1[1], span2[1]) + 1
+                        ):
+                            live1 = generate_t1[ts] + preserve_t1[ts] + fetch_t1[ts]
+                            live2 = generate_t2[ts] + preserve_t2[ts] + fetch_t2[ts]
+                            overlap_at_t = live1 + live2 - 1
+                            solver.add_constraint(
+                                v1 + v2 >= overlap_at_t,
+                                name=f"{utils.get_linenumber()}_{t1.name}_overlaps_{t2.name}@{ts}",
+                            )
+
+        #####################################################
+
+        elif defrag:
+
+            # Maximum address that can be used
+            max_address = (
+                min(self.ComputeMaximumMemoryRequired(), mem_limit)
+                - persistent_weight_size
+            ) // gcd
+
+            # Create a new variable for each tensor that tracks the base address
+            # of the tensor. If the tensor is of size 0, we force its address to be
+            # 0 to help the solver
+            addresses = defaultdict(lambda: {})
+            for tensor in self.graph.edges.values():
+                for t in self.TimeStepsForEdge(tensor, spans):
+                    if tensor.size > 0 and (
+                        not tensor.is_stateful() or spilling_allowed
+                    ):
+                        v = solver.create_integer_var(
+                            tensor.name + "@" + str(t),
+                            lower_bound=0,
+                            upper_bound=max_address - tensor.size // gcd,
+                        )
+                        addresses[tensor][t] = v
+
+            for e in self.graph.edges.values():
+                if e.size == 0 or (e.is_stateful() and (not spilling_allowed)):
+                    continue
+                addresses_e = self.DensePreserveVarsMap(addresses[e])
+                preserve_e = self.DensePreserveVarsMap(preserve_vars[e])
+                prev = self.TimeStepsForEdge(e, spans)
+                for t in self.TimeStepsForEdge(e, spans, startoffset=1):
+                    # If preserve[t], then address[t] must be equal to address[t-1]. This is encoded as:
+                    # address[t] - address[t-1] <= (1-preserve) * max_address
+                    # address[t-1] - address[t] <= (1-preserve) * max_address
+                    p = prev.__next__()
+                    solver.add_constraint(
+                        addresses_e[t] - addresses_e[p]
+                        <= (1 - preserve_e[t]) * max_address
+                    )
+                    solver.add_constraint(
+                        addresses_e[p] - addresses_e[t]
+                        <= (1 - preserve_e[t]) * max_address
+                    )
+
+            liveness = defaultdict(lambda: [])
+            for e in self.graph.edges.values():
+                if e.size == 0 or (e.is_stateful() and (not spilling_allowed)):
+                    continue
+                lb, ub = makespan[e]
+                for ts in range(lb, ub + 1):
+                    liveness[ts].append(e)
+
+            for ts, edges in liveness.items():
+                processed = set()
+                for t1 in edges:
+                    for t2 in edges:
+                        if t1 is t2 or (t2, t1) in processed:
+                            continue
+                        processed.add((t1, t2))
+                        if not self.graph.can_overlap_in_time(t1, t2):
+                            # print(t1.name + " and " + t2.name + "CANNOT OVERLAP 2")
+                            continue
+                        # Check if both t1 and t2 are live at ts.
+                        generate_t1 = self.DenseGenerateOrFetchVarsMap(
+                            generate_vars[t1]
+                        )
+                        preserve_t1 = self.DensePreserveVarsMap(preserve_vars[t1])
+                        fetch_t1 = self.DenseGenerateOrFetchVarsMap(fetch_vars[t1])
+                        addresses_t1 = self.DensePreserveVarsMap(addresses[t1])
+                        generate_t2 = self.DenseGenerateOrFetchVarsMap(
+                            generate_vars[t2]
+                        )
+                        preserve_t2 = self.DensePreserveVarsMap(preserve_vars[t2])
+                        fetch_t2 = self.DenseGenerateOrFetchVarsMap(fetch_vars[t2])
+                        addresses_t2 = self.DensePreserveVarsMap(addresses[t2])
+
+                        live1 = generate_t1[ts] + preserve_t1[ts] + fetch_t1[ts]
+                        live2 = generate_t2[ts] + preserve_t2[ts] + fetch_t2[ts]
+                        # overlap_at_ts = solver.create_binary_var(
+                        #    t1.name + "_" + t2.name + "_overlap_at_" + str(ts)
+                        # )
+                        # solver.add_constraint(overlap_at_ts <= live1)
+                        # solver.add_constraint(overlap_at_ts <= live2)
+                        # solver.add_constraint(overlap_at_ts + 1 >= live1 + live2)
+                        # Make sure overlap at ts < 1 if the 2 tensors don't overlap in time.
+                        overlap_at_ts = live1 + live2 - 1
+
+                        # if t1 and t2 are both live at ts, one of these 2 constraints must hold:
+                        # variables[t1] + t1.size <= variables[t2]
+                        # variables[t1] >= variables[t2] + t2.size
+                        # If the size of t1 is the same as the size of t2, we only use the first
+                        # constraint.
+                        if False:  # t1.size == t2.size:
+                            v1 = solver.create_binary_var(
+                                t1.name + "_" + t2.name + "_v1_at_" + str(ts)
+                            )
+                            solver.add_constraint(
+                                addresses_t1[ts] + t1.size // gcd - addresses_t2[ts]
+                                <= (1 - v1) * max_address
+                            )
+                            solver.add_constraint(overlap_at_ts <= v1)
+                        else:
+                            v1 = solver.create_binary_var(
+                                t1.name + "_" + t2.name + "_v1_at_" + str(ts)
+                            )
+                            solver.add_constraint(
+                                addresses_t1[ts] + t1.size // gcd - addresses_t2[ts]
+                                <= (1 - v1) * max_address
+                            )
+                            v2 = solver.create_binary_var(
+                                t1.name + "_" + t2.name + "_v2_at_" + str(ts)
+                            )
+                            solver.add_constraint(
+                                addresses_t1[ts] - addresses_t2[ts] - t2.size // gcd
+                                >= (v2 - 1) * max_address
+                            )
+
+                            solver.add_constraint(v1 + v2 >= overlap_at_ts)
+                            # solver.add_constraint(2 - v1 - v2 >= overlap_at_ts)
+
+        #####################################################
+
+        # Add objective function
+        s = 0
+        if allow_rematerialization:
+            # Minimize the number of data generations
+            for e, ts in generate_vars.items():
+                if not e.source.time:
+                    continue
+                for v in ts.values():
+                    s += v * e.source.time
+
+        if max_spills is None:
+            # Minimize the number of spills
+            for e, ts in fetch_vars.items():
+                for v in ts.values():
+                    s += v * (e.size * 2 // gcd)
+
+            for n in self.graph.nodes.values():
+                if n.op_type != "stateful_node_sink":
+                    continue
+                for edge in n.fanin:
+                    missing_during_startup = 1 - generate_vars[edge][1]
+                    missing_during_cleanup = 1 - preserve_vars[edge][num_timesteps]
+                    extra_spill = solver.create_binary_var(edge.name + "_extra_spill")
+                    solver.add_constraint(
+                        extra_spill >= missing_during_startup,
+                        name=f"{utils.get_linenumber()}_spilled_at_startup_for_{edge.name}",
+                    )
+                    solver.add_constraint(
+                        extra_spill >= missing_during_cleanup,
+                        name=f"{utils.get_linenumber()}_spilled_at_cleanup_for_{edge.name}",
+                    )
+                    # Unnecessary and slows us down
+                    # solver.add_constraint(
+                    #    extra_spill <= missing_during_startup + missing_during_cleanup
+                    # )
+                    factor = 1 if edge.source.read_only else 2
+                    s += extra_spill * (edge.size * factor // gcd)
+
+        if max_spills is not None and not allow_rematerialization:
+            # Minimize peak memory usage
+            min_peak_mem = min_memory_requirement
+            if not min_memory_requirement_acurate and not spilling_allowed:
+                for n in self.graph.nodes.values():
+                    if n.is_stateful():
+                        continue
+                    node_activations = 0
+                    for f in itertools.chain(n.fanin, n.fanout):
+                        if not f.is_stateful():
+                            node_activations += f.size
+                    min_peak_mem = min(min_peak_mem, node_activations)
+
+            max_usage = (
+                min(self.ComputeMaximumMemoryRequired(), mem_limit)
+                - persistent_weight_size
+            ) // gcd
+            v = solver.create_integer_var(
+                "peak_memory_usage",
+                lower_bound=min_peak_mem // gcd,
+                upper_bound=max_usage,
+            )
+            s += v
+            if defrag:
+                for t, p in addresses.items():
+                    for ts, a in p.items():
+                        solver.add_constraint(
+                            v >= a + t.size // gcd,
+                            name=f"{utils.get_linenumber()}_max_address_above_{t.name}@{ts}",
+                        )
+            elif account_for_fragmentation:
+                for t, a in addresses.items():
+                    solver.add_constraint(
+                        v >= a + t.size // gcd,
+                        name=f"{utils.get_linenumber()}_max_address_above_{t.name}",
+                    )
+            else:
+                for ts, m in mem_at_timestep.items():
+                    solver.add_constraint(
+                        v >= m, name=f"{utils.get_linenumber()}_max_address@{ts}"
+                    )
+
+        solver.set_objective_function(s, maximize=False)
+
+        # start_time = time.time()
+        # print("Start ILP solver")
+        # print("PROBLEM STATS = " + str(solver))
+
+        result = solver.solve()
+        # print(f"ILP solver time: {time.time()-start_time} seconds")
+
+        if self.print_relaxation:
+            relaxed_solution = solver.solve_relaxation()
+            print("CHECKING LP RELAXATION")
+            for var, value in result.items():
+                if var.VType == "B":
+                    if abs(value - relaxed_solution[var.varName]) > 0.5:
+                        print(
+                            f" Var {var.varName} flipped: relaxed value {relaxed_solution[var.varName]} vs integral value {value}"
+                        )
+                    elif abs(value - relaxed_solution[var.varName]) > 0.05:
+                        print(
+                            f" Var {var.varName} far from relaxed value {relaxed_solution[var.varName]}: integral value {value}"
+                        )
+                else:
+                    if abs(value - relaxed_solution[var.varName]) > 0.5:
+                        print(
+                            f" Var {var.varName} changed: relaxed value {relaxed_solution[var.varName]} vs integral value {value}"
+                        )
+
+        last_uses = {}
+        for e in self.graph.edges.values():
+            last_use = 0
+            for sink in e.sinks:
+                if len(sink.fanout) == 0:
+                    last_use = max(last_use, alap[sink])
+                else:
+                    for fanout in sink.fanout:
+                        for t, v in generate_vars[fanout].items():
+                            if result[v] >= 0.99:
+                                last_use = max(last_use, t)
+
+            last_uses[e] = last_use
+
+        schedule = defaultdict(lambda: ([], [], []))
+        mem_locations = defaultdict(lambda: {})
+        materialization_count = {}
+        for n, ts in generate_vars.items():
+            tensor_materialization_count = 0
+            for t, v in ts.items():
+                if result[v] >= 0.99:
+                    tensor_materialization_count += 1
+                    if account_for_fragmentation:
+                        if n.size == 0:
+                            schedule[n][0].append(str(t) + "[ctrl]")
+                        elif n.is_stateful() and (not spilling_allowed):
+                            schedule[n][0].append(str(t) + "[weight]")
+                        else:
+                            if defrag:
+                                schedule[n][0].append(
+                                    str(t)
+                                    + "@"
+                                    + str(int(result[addresses[n][t]] * gcd))
+                                )
+                                mem_locations[t][n] = int(result[addresses[n][t]] * gcd)
+                            else:
+                                schedule[n][0].append(
+                                    str(t) + "@" + str(int(result[addresses[n]] * gcd))
+                                )
+                                mem_locations[t][n] = int(result[addresses[n]] * gcd)
+
+                    else:
+                        schedule[n][0].append(t)
+            # Don't double count nodes with multiple outputs
+            if n.source in materialization_count:
+                assert materialization_count[n.source] == tensor_materialization_count
+            else:
+                materialization_count[n.source] = tensor_materialization_count
+
+        # Sanity check: each tensor must have been generated in the [asap, alap] window
+        # of its source node
+        for n, ts in generate_vars.items():
+            src = n.source
+            last = alap[src]
+            generated = 0
+            for t, v in ts.items():
+                if t > last:
+                    break
+                generated += result[v]
+            assert generated >= 0.99
+
+        for n, ts in preserve_vars.items():
+            if account_for_fragmentation and defrag and n.size > 0:
+                addresses_n = self.DensePreserveVarsMap(addresses[n])
+            for t, v in self.DensePreserveVarsMap(ts).items():
+                if t > last_uses[n]:
+                    continue
+                if result[v] >= 0.99:
+                    schedule[n][1].append(t)
+                    if n.size == 0:
+                        continue
+                    if n.is_stateful() and (not spilling_allowed):
+                        continue
+                    if defrag:
+                        mem_locations[t][n] = int(result[addresses_n[t]] * gcd)
+                    elif account_for_fragmentation:
+                        mem_locations[t][n] = int(result[addresses[n]] * gcd)
+
+        for n, ts in fetch_vars.items():
+            for t, v in ts.items():
+                if t > last_uses[n]:
+                    continue
+                if result[v] >= 0.99:
+                    if defrag:
+                        schedule[n][2].append(
+                            str(t) + "@" + str(int(result[addresses[n][t]] * gcd))
+                        )
+                        mem_locations[t][n] = int(result[addresses[n][t]] * gcd)
+                    else:
+                        schedule[n][2].append(t)
+                        if account_for_fragmentation:
+                            mem_locations[t][n] = int(result[addresses[n]] * gcd)
+
+        mem_at_timestep = defaultdict(lambda: 0)
+        tensors_swapped = defaultdict(lambda: 0)
+        for e, ts in preserve_vars.items():
+            for t, v in self.DensePreserveVarsMap(ts).items():
+                if t <= last_uses[e]:
+                    mem_at_timestep[t] += result[v] * e.size
+        for e, ts in generate_vars.items():
+            for t, v in ts.items():
+                if t <= last_uses[e]:
+                    mem_at_timestep[t] += result[v] * e.size
+        for e, ts in fetch_vars.items():
+            for t, v in ts.items():
+                if t > last_uses[e]:
+                    continue
+                mem_at_timestep[t] += result[v] * e.size
+                if result[v] >= 0.99:
+                    tensors_swapped[e] += 1
+
+        peak_mem_usage = 0
+        for mem_usage in mem_at_timestep.values():
+            peak_mem_usage = max(peak_mem_usage, mem_usage)
+
+        total_data_swapped = 0
+        for e, count in tensors_swapped.items():
+            total_data_swapped += (count + 1) * e.size
+
+        for n in self.graph.nodes.values():
+            if n.op_type != "stateful_node_sink":
+                continue
+            if not spilling_allowed:
+                continue
+            for edge in n.fanin:
+                present_at_startup = result[generate_vars[edge][1]]
+                present_at_cleanup = result[preserve_vars[edge][num_timesteps]]
+                if not present_at_startup or not present_at_cleanup:
+                    factor = 1 if edge.source.read_only else 2
+                    total_data_swapped += edge.size * factor
+
+        if defrag:
+            required_memory = 0
+            for t, p in addresses.items():
+                if t.size == 0:
+                    continue
+                elif t.is_stateful() and (not spilling_allowed):
+                    continue
+                for timestamp, a in p.items():
+                    if timestamp <= last_uses[e]:
+                        required_memory = max(required_memory, result[a] * gcd + t.size)
+            required_memory += persistent_weight_size
+
+        elif account_for_fragmentation:
+            required_memory = 0
+            for t, a in addresses.items():
+                if t.size == 0:
+                    continue
+                elif t.is_stateful() and (not spilling_allowed):
+                    continue
+                required_memory = max(required_memory, result[a] * gcd + t.size)
+            required_memory += persistent_weight_size
+
+        else:
+            required_memory = peak_mem_usage
+
+        rematerialization_count = 0
+        rematerialization_time = 0
+        if allow_rematerialization:
+            for node, count in materialization_count.items():
+                if count == 1:
+                    continue
+                rematerialization_count += count - 1
+                if node.time is not None:
+                    rematerialization_time += (count - 1) * node.time
+
+        summary = {
+            "peak_mem_usage": peak_mem_usage,
+            "total_data_swapped": total_data_swapped,
+            "required_memory": required_memory,
+            "rematerialization_count": rematerialization_count,
+            "rematerialization_time": rematerialization_time,
+        }
+        return (summary, schedule, mem_locations)

--- a/olla/utils.py
+++ b/olla/utils.py
@@ -1,0 +1,146 @@
+from inspect import currentframe
+
+import intervaltree
+from olla import dataflow_graph
+
+
+def get_linenumber():
+    cf = currentframe()
+    return cf.f_back.f_lineno
+
+
+def extract_node_ordering(graph, schedule):
+    node_ordering = {}
+    for t, s in schedule.items():
+        generated = parse_schedule_item(s[0][0])
+        if t.source in node_ordering:
+            assert node_ordering[t.source] == generated
+        else:
+            node_ordering[t.source] = generated
+
+    # Special case for nodes that have no fanout
+    for n in graph.nodes.values():
+        if len(n.fanout) > 0:
+            continue
+        if n.is_stateful():
+            continue
+        available = set()
+        for i in range(0, len(n.fanin)):
+            s = schedule[n.fanin[i]]
+
+            fanin_availability = set(s[1])
+            for generate in s[0]:
+                fanin_availability.add(parse_schedule_item(generate) + 1)
+            if i == 0:
+                available = fanin_availability
+            else:
+                available.intersection_update(fanin_availability)
+
+        if not available:
+            continue
+        else:
+            node_ordering[n] = sorted(available)[0]
+
+    return node_ordering
+
+
+# Make sure that tensors never overlap in time
+def validate_address_allocation(memory_locations, verbose=True):
+    for ts, pairs in memory_locations.items():
+        used_addresses = intervaltree.IntervalTree()
+        for tensor, address in pairs.items():
+            if tensor.size == 0:
+                continue
+            if used_addresses.overlaps(address, address + tensor.size):
+                print(
+                    f"tensor {tensor.name} at address {address} overlaps at timestep {ts} with {str(used_addresses[address : address + tensor.size])}",
+                    flush=True,
+                )
+                return False
+            used_addresses[address : address + tensor.size] = tensor
+
+    return True
+
+
+def parse_schedule_item(item):
+    item = str(item)
+    item = item.split("[")[0]
+    items = item.split("@")
+    assert len(items) > 0
+    return int(items[0])
+
+
+def check_op_inputs(tensor, allocate, schedule, verbose=True):
+    assert tensor.source is not None
+    op = tensor.source
+    for fanin in op.fanin:
+        preserve = schedule[fanin][1]
+        spills = [parse_schedule_item(i) for i in schedule[fanin][2]]
+        for t in allocate:
+            if t not in preserve and t not in spills:
+                if verbose:
+                    print(
+                        f"Input tensor {fanin.name} not in memory when op {op.name} driving {tensor.name} is run at time {t}"
+                    )
+                return False
+    return True
+
+
+def validate_timeline(schedule, verbose=True):
+    for tensor, s in schedule.items():
+        if isinstance(tensor, dataflow_graph.Node):
+            continue
+
+        allocate = [parse_schedule_item(i) for i in s[0]]
+
+        if not check_op_inputs(tensor, allocate, schedule, verbose):
+            return False
+
+        if tensor.size == 0:
+            continue
+        preserve = s[1]
+        if len(preserve) == 0:
+            continue
+
+        spills = [parse_schedule_item(i) for i in s[2]]
+
+        if preserve[0] - 1 not in allocate and preserve[0] - 1 not in spills:
+            print(
+                f"tensor {tensor.name} was not allocated/fetched before timestep {preserve[0]}"
+            )
+            return False
+
+        for i in range(1, len(preserve) - 1):
+            if preserve[i] == preserve[i - 1] + 1:
+                continue
+            if preserve[i] - 1 in spills:
+                continue
+            if preserve[i] - 1 in allocate:
+                continue
+
+            print(
+                f"tensor {tensor.name} was not allocated/fetched/preserved before timestep {preserve[i]}"
+            )
+            return False
+
+    return True
+
+
+def validate_node_ordering(graph, schedule, verbose=True):
+    node_order = extract_node_ordering(graph, schedule)
+    order = []
+    for node, ts in node_order.items():
+        order.append((ts, node))
+    order.sort(key=lambda obj: obj[0])
+    already_executed = set()
+    for _, node in order:
+        for fi in node.fanin:
+            for src in fi.sources:
+                if src not in already_executed:
+                    print(
+                        f"Invalid order: {node.name} scheduled before its fanin {src.name}"
+                    )
+                    print(f"Complete ordering {[node.name for _, node in order]}")
+                    return False
+        already_executed.add(node)
+    return True

--- a/olla/visualizer.py
+++ b/olla/visualizer.py
@@ -1,0 +1,52 @@
+import math
+
+from PIL import Image, ImageDraw
+from olla import utils
+
+
+def draw_schedule(schedule, img_path="/tmp/output.png"):
+
+    max_ts = 0
+    max_address = 0
+    boxes = {}
+    for tensor, s in schedule.items():
+        print(f"Tensor {tensor.name}, schedule = {s}")
+        # No support for rematerialization yet
+        assert len(s[0]) == 1
+        # No support for spilling yet
+        assert len(s[2]) == 0
+        # Skip items for which we don't generate addresses
+        if s[0][0].endswith("[weight]") or s[0][0].endswith("[ctrl]"):
+            continue
+
+        items = s[0][0].split("@")
+        assert len(items) == 2
+        allocate = int(items[0])
+        address = int(items[1])
+        deallocate = utils.parse_schedule_item(s[1][-1]) if len(s[1]) > 0 else allocate
+        boxes[tensor] = (allocate, deallocate, address)
+        print(f"    {boxes[tensor]}")
+        max_ts = max(max_ts, deallocate)
+        max_address = max(max_address, address + tensor.size)
+
+    print("Create img")
+    ts_factor = math.ceil(max_address / max_ts)
+    img = Image.new(mode="RGB", size=(1280, 1280), color=(200, 200, 200))
+    ts_factor = 1280 / (max_ts + 1)
+    address_factor = 1280 / max_address
+
+    print("Create draw")
+    draw = ImageDraw.Draw(img)
+
+    for tensor, box in boxes.items():
+        # print(f"drawing {tensor.name}")
+        coordinates = (
+            box[0] * ts_factor,
+            box[2] * address_factor,
+            (box[1] + 1) * ts_factor,
+            (box[2] + tensor.size) * address_factor,
+        )
+        draw.rectangle(coordinates, fill=(50, 50, 200), outline=(255, 255, 255))
+        draw.text(coordinates[:2], tensor.name, fill=(0, 0, 0))
+    print("Save img")
+    img.save(img_path, "PNG")

--- a/tests/dataflow_graph_test.py
+++ b/tests/dataflow_graph_test.py
@@ -1,0 +1,1017 @@
+import unittest
+
+from olla import dataflow_graph
+
+
+class DataflowGraphTest(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def compare_items(self, node, other):
+        return vars(node) == vars(other)
+
+    def compare_item_lists(self, nodes, others):
+        equal = []
+        for (
+            node,
+            other,
+        ) in zip(nodes, others):
+            equal.append(self.compare_items(node, other))
+
+        return all(equal)
+
+    def testMultiEdge(self):
+        g = dataflow_graph.Graph()
+
+        a = g.add_node(name="a")
+        b = g.add_node(name="b")
+        c = g.add_node(name="c")
+        d = g.add_node(name="d")
+
+        e1 = g.add_edge([a], [b], 123)
+        e2 = g.add_edge([a, b], [c], 456)
+        e3 = g.add_edge([c], [d], 789)
+
+        g.canonicalize()
+        self.assertTrue(g.check_consistency())
+        self.assertTrue(g.is_valid())
+
+        g.dump("/tmp/test.dump")
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\ta [label="<f0> a_0|<f1> a_1"]
+\tb [label=b]
+\tc [label=c]
+\td [label=d]
+\tallocate_2 [label="allocate_2 (allocate_tensor)"]
+\ta:f0 -> b [label=123]
+\ta:f1 -> c [label=0]
+\tb -> c [label=0]
+\tc -> d [label=789]
+\tallocate_2 -> c [label=456]
+\tallocate_2 -> a [label=456]
+\tallocate_2 -> b [label=456]
+}
+""",
+        )
+
+        # Test adding sinks and sources to edges
+        e1.add_sink(c)
+        e2.add_source(c)
+        e2.add_sources([a, d])
+        e3.add_sinks([a, b])
+
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\ta [label="<f0> a_0|<f1> a_1|<f2> a_2"]
+\tb [label=b]
+\tc [label="<f0> c_0|<f1> c_1"]
+\td [label=d]
+\tallocate_2 [label="allocate_2 (allocate_tensor)"]
+\ta:f0 -> b [label=123]
+\ta:f0 -> c [label=123]
+\ta:f1 -> c [label=0]
+\ta:f2 -> c [label=456]
+\tb -> c [label=0]
+\tc:f0 -> d [label=789]
+\tc:f0 -> a [label=789]
+\tc:f0 -> b [label=789]
+\tc:f1 -> c [label=456]
+\td -> c [label=456]
+\tallocate_2 -> c [label=456]
+\tallocate_2 -> a [label=456]
+\tallocate_2 -> b [label=456]
+}
+""",
+        )
+
+    def testLineGraph(self):
+        g = dataflow_graph.Graph()
+
+        A = g.add_node(name="a")
+        B = g.add_node(name="b")
+        C = g.add_node(name="c")
+        D = g.add_node(name="d")
+        E = g.add_node(name="e")
+        F = g.add_node(name="f")
+        G = g.add_node(name="g")
+        H = g.add_node(name="h")
+        J = g.add_node(name="j")
+        K = g.add_node(name="k")
+
+        g.add_edge([A], [B], 123, name="e1")
+        g.add_edge([B], [C, J], 456, name="e2")
+        g.add_edge([C], [D], 789, name="e3")
+        g.add_edge([C], [K], 789, name="e4")
+        g.add_edge([A], [E, G], 1034, name="e5")
+        g.add_edge([E], [F], 1045, name="e6")
+        g.add_edge([F], [G], 1067, name="e7")
+        g.add_edge([G], [H], 1089, name="e8")
+
+        g.canonicalize()
+        # print(str(g.nodes))
+        # print(str(g.edges))
+
+        self.assertTrue(g.check_consistency())
+        self.assertTrue(g.is_valid())
+
+        line_graph = g.build_line_graph()
+
+        # print(str(line_graph.nodes))
+        # print(str(line_graph.edges))
+
+        dot = line_graph.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\te1 [label=e1]
+\te2 [label=e2]
+\te3 [label=e3]
+\te4 [label=e4]
+\te5 [label="<f0> e5_0|<f1> e5_1"]
+\te6 [label=e6]
+\te7 [label=e7]
+\te8 [label=e8]
+\te1 -> e2 [label=0]
+\te2 -> e3 [label=0]
+\te2 -> e4 [label=0]
+\te5:f0 -> e6 [label=0]
+\te5:f1 -> e8 [label=0]
+\te6 -> e7 [label=0]
+\te7 -> e8 [label=0]
+}
+""",
+        )
+
+    def testGraphWithWeights(self):
+        g = dataflow_graph.Graph()
+
+        A = g.add_node(name="INPUT")
+        B = g.add_node(name="WEIGHT", size=123)
+        C = g.add_node(name="OPERATOR")
+        D = g.add_node(name="OUTPUT")
+
+        g.add_edge([A], [C], size=10)
+        g.add_edge([B], [C], size=20)
+        g.add_edge([C], [D], size=50)
+
+        g.canonicalize()
+        self.assertTrue(g.check_consistency())
+        self.assertTrue(g.is_valid())
+
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\tINPUT [label=INPUT]
+\tWEIGHT [label="WEIGHT (stateful_node)"]
+\tOPERATOR [label=OPERATOR]
+\tOUTPUT [label=OUTPUT]
+\tWEIGHT_snk [label="WEIGHT_snk (stateful_node_sink)"]
+\tINPUT -> OPERATOR [label=10]
+\tWEIGHT -> OPERATOR [label=143]
+\tWEIGHT -> WEIGHT_snk [label=143]
+\tOPERATOR -> OUTPUT [label=50]
+}
+""",
+        )
+
+    def testGraphStructureQueries(self):
+        g = dataflow_graph.Graph()
+
+        A = g.add_node(name="a")
+        B = g.add_node(name="b")
+        C = g.add_node(name="c")
+        D = g.add_node(name="d")
+        E = g.add_node(name="e")
+        F = g.add_node(name="f")
+        G = g.add_node(name="g")
+        H = g.add_node(name="h")
+        J = g.add_node(name="j")
+        K = g.add_node(name="k")
+
+        g.add_edge([A], [B], 123, name="e1")
+        g.add_edge([B], [C, J], 456, name="e2")
+        g.add_edge([C], [D], 789, name="e3")
+        g.add_edge([C], [K], 789, name="e4")
+        g.add_edge([A], [E, G], 1034, name="e5")
+        g.add_edge([E], [F], 1045, name="e6")
+        g.add_edge([F], [G], 1067, name="e7")
+        g.add_edge([G], [H], 1089, name="e8")
+
+        g.canonicalize()
+
+        self.assertTrue(g.is_in_immediate_fanin(A, B))
+        self.assertTrue(g.is_in_immediate_fanin(B, C))
+        self.assertTrue(g.is_in_immediate_fanin(B, J))
+        self.assertTrue(g.is_in_immediate_fanin(C, D))
+        self.assertTrue(g.is_in_immediate_fanin(C, K))
+        self.assertTrue(g.is_in_immediate_fanin(A, E))
+        self.assertTrue(g.is_in_immediate_fanin(A, G))
+        self.assertTrue(g.is_in_immediate_fanin(E, F))
+        self.assertTrue(g.is_in_immediate_fanin(F, G))
+        self.assertTrue(g.is_in_immediate_fanin(G, H))
+
+        self.assertTrue(g.is_in_transitive_fanin(A, B))
+        self.assertTrue(g.is_in_transitive_fanin(B, C))
+        self.assertTrue(g.is_in_transitive_fanin(B, J))
+        self.assertTrue(g.is_in_transitive_fanin(C, D))
+        self.assertTrue(g.is_in_transitive_fanin(C, K))
+        self.assertTrue(g.is_in_transitive_fanin(A, E))
+        self.assertTrue(g.is_in_transitive_fanin(A, G))
+        self.assertTrue(g.is_in_transitive_fanin(E, F))
+        self.assertTrue(g.is_in_transitive_fanin(F, G))
+        self.assertTrue(g.is_in_transitive_fanin(G, H))
+
+        self.assertTrue(g.is_in_transitive_fanin(A, C))
+        self.assertTrue(g.is_in_transitive_fanin(A, J))
+        self.assertTrue(g.is_in_transitive_fanin(B, D))
+        self.assertTrue(g.is_in_transitive_fanin(B, K))
+        self.assertTrue(g.is_in_transitive_fanin(A, F))
+        self.assertTrue(g.is_in_transitive_fanin(E, G))
+        self.assertTrue(g.is_in_transitive_fanin(A, H))
+
+        self.assertTrue(g.is_in_transitive_fanin(A, D))
+        self.assertTrue(g.is_in_transitive_fanin(A, K))
+        self.assertTrue(g.is_in_transitive_fanin(A, G))
+        self.assertTrue(g.is_in_transitive_fanin(A, F))
+        self.assertTrue(g.is_in_transitive_fanin(A, G))
+
+        self.assertFalse(g.is_in_transitive_fanin(D, C))
+        self.assertFalse(g.is_in_transitive_fanin(K, C))
+        self.assertFalse(g.is_in_transitive_fanin(G, A))
+        self.assertFalse(g.is_in_transitive_fanin(E, A))
+        self.assertFalse(g.is_in_transitive_fanin(B, A))
+        self.assertFalse(g.is_in_transitive_fanin(E, B))
+        self.assertFalse(g.is_in_transitive_fanin(B, E))
+
+    def testGraphStructureNegativeQueries(self):
+        g = dataflow_graph.Graph()
+
+        A = g.add_node(name="a")
+        B = g.add_node(name="b")
+        C = g.add_node(name="c")
+        D = g.add_node(name="d")
+        E = g.add_node(name="e")
+        F = g.add_node(name="f")
+        G = g.add_node(name="g")
+
+        g.add_edge([A], [B], 123, name="e1")
+        g.add_edge([A], [C], 456, name="e2")
+        g.add_edge([B], [D], 789, name="e3")
+        g.add_edge([C], [D], 789, name="e4")
+        g.add_edge([D], [E, F], 1034, name="e5")
+        g.add_edge([E], [G], 1045, name="e6")
+        g.add_edge([F], [G], 1089, name="e8")
+
+        g.canonicalize()
+
+        self.assertFalse(g.is_in_transitive_fanin(A, A))
+
+        self.assertTrue(g.is_in_transitive_fanin(A, G))
+        self.assertTrue(g.is_in_transitive_fanin(A, F))
+        self.assertTrue(g.is_in_transitive_fanin(B, G))
+
+    def testPruning(self):
+        g = dataflow_graph.Graph()
+        C0 = g.add_node(name="Conv0")
+        C1 = g.add_node(name="Conv1")
+        C2 = g.add_node(name="Conv2")
+        Cp = g.add_node(name="Copy", op_type="turing::copy")
+
+        g.add_edge([C0], [C1], size=123, name="e0")
+        g.add_edge([C1, Cp], [C2], size=456, name="e1")
+        g.add_edge([C1, Cp], [C2], size=0, name="e2")
+
+        g.prune()
+        g.canonicalize()
+        print(str(g))
+
+        self.assertEqual(
+            str(g),
+            """Conv0 (None)
+Conv1 (None)
+Conv2 (None)
+
+e0: Conv0 (None) -> [Conv1 (None)] size=123
+e1: Conv1 (None) -> [Conv2 (None)] size=456
+e2: Conv1 (None) -> [Conv2 (None)] size=0
+""",
+        )
+
+    def testAggressivePruning(self):
+        g = dataflow_graph.Graph()
+        C0 = g.add_node(name="Conv0")
+        C1 = g.add_node(name="Conv1")
+        C2 = g.add_node(name="Conv2")
+        Cp = g.add_node(name="Copy", op_type="turing::copy")
+
+        g.add_edge([C0], [C1], size=123, name="e0")
+        g.add_edge([C1], [Cp], size=0, name="e1")
+        g.add_edge([C1, Cp], [C2], size=456, name="e2")
+
+        g.prune(aggressive=True)
+        g.canonicalize()
+        print(str(g))
+
+        self.assertEqual(
+            str(g),
+            """Conv0 (None)
+Conv1 (None)
+Conv2 (None)
+
+e0: Conv0 (None) -> [Conv1 (None)] size=123
+e2: Conv1 (None) -> [Conv2 (None)] size=456
+""",
+        )
+
+    def testAggressivePruning2(self):
+        g = dataflow_graph.Graph()
+        C1 = g.add_node(name="Conv1")
+        C2 = g.add_node(name="Conv2")
+        C3 = g.add_node(name="Conv3")
+        Cp1 = g.add_node(name="Copy1", op_type="turing::copy")
+        Cp2 = g.add_node(name="Copy2", op_type="turing::copy")
+        Cp3 = g.add_node(name="Copy3", op_type="turing::copy")
+
+        g.add_edge([C1], [Cp1, Cp2, Cp3], size=123, name="e0")
+        g.add_edge([Cp1, Cp2, Cp3], [C2], size=456, name="e1")
+        g.add_edge([C2], [C3], size=789, name="e2")
+        g.add_edge([Cp3], [C3], size=0, name="e3")
+
+        g.prune(aggressive=True)
+        print(str(g))
+
+        self.assertEqual(
+            str(g),
+            """Conv1 (None)
+Conv2 (None)
+Conv3 (None)
+Copy1 (turing::copy)
+Copy3 (turing::copy)
+
+MultiSourceEdge e0, size:123, mem_space:None, tile_id:None group_id:None sources:[Conv1 (None)] sinks:[Copy1 (turing::copy), Copy3 (turing::copy)]
+MultiSourceEdge e1, size:456, mem_space:None, tile_id:None group_id:None sources:[Copy1 (turing::copy), Copy3 (turing::copy)] sinks:[Conv2 (None)]
+MultiSourceEdge e2, size:789, mem_space:None, tile_id:None group_id:None sources:[Conv2 (None)] sinks:[Conv3 (None)]
+MultiSourceEdge e3, size:0, mem_space:None, tile_id:None group_id:None sources:[Copy3 (turing::copy)] sinks:[Conv3 (None)]
+""",
+        )
+
+    def testDominatorTree(self):
+        g = dataflow_graph.Graph()
+        Z = g.add_node(name="Z")
+        R = g.add_node(name="R")
+        A = g.add_node(name="A")
+        B = g.add_node(name="B")
+        C = g.add_node(name="C")
+        D = g.add_node(name="D")
+        E = g.add_node(name="E")
+        F = g.add_node(name="F")
+        G = g.add_node(name="G")
+        H = g.add_node(name="H")
+        I = g.add_node(name="I")
+        J = g.add_node(name="J")
+        K = g.add_node(name="K")
+        L = g.add_node(name="L")
+        g.add_edge([Z], [R], 0, name="e0")
+        g.add_edge([R], [A, B, C], 0, name="e1")
+        g.add_edge([A], [D], 0, name="e2")
+        g.add_edge([B], [A, D, E], 0, name="e3")
+        g.add_edge([C], [F, G], 0, name="e4")
+        g.add_edge([D], [L], 0, name="e5")
+        g.add_edge([E], [H], 0, name="e6")
+        g.add_edge([F], [I], 0, name="e7")
+        g.add_edge([G], [I, J], 0, name="e8")
+        g.add_edge([H], [E, K], 0, name="e9")
+        g.add_edge([I], [K], 0, name="e10")
+        g.add_edge([J], [I], 0, name="e11")
+        g.add_edge([K], [I, R], 0, name="e12")
+        g.add_edge([L], [H], 0, name="e13")
+        g.canonicalize()
+        # print(str(g))
+        dom_tree = g.build_dominator_tree()
+        print(str(dom_tree))
+
+        self.assertEqual(
+            str(dom_tree),
+            """R dominated by Z
+C dominated by R
+G dominated by C
+J dominated by G
+F dominated by C
+B dominated by R
+A dominated by R
+D dominated by R
+L dominated by D
+H dominated by R
+K dominated by R
+I dominated by R
+E dominated by R
+""",
+        )
+
+        self.assertEqual(dom_tree.lowest_common_ancestor([A, B, C, D, E]), R)
+        self.assertEqual(dom_tree.lowest_common_ancestor([F, G]), C)
+        self.assertEqual(dom_tree.lowest_common_ancestor([J, K]), R)
+
+    def testDominatorTreeWithAllocs(self):
+        g = dataflow_graph.Graph()
+        C0 = g.add_node(name="Conv0")
+        C1 = g.add_node(name="Conv1")
+        C2 = g.add_node(name="Conv2")
+        Cp = g.add_node(name="Copy")
+
+        g.add_edge([C0], [C1], 123, name="e0")
+        g.add_edge([C1, Cp], [C2], 456, name="e1")
+
+        g.canonicalize()
+        print(str(g))
+        dom_tree = g.build_dominator_tree()
+        print(str(dom_tree))
+
+        self.assertEqual(
+            str(dom_tree),
+            """Conv1 dominated by Conv0
+Conv2 dominated by Conv1
+""",
+        )
+
+    def testDominatorTreeWithWeights(self):
+        g = dataflow_graph.Graph()
+        C0 = g.add_node(name="X")
+        C1 = g.add_node(name="W", op_type="weight")
+        C2 = g.add_node(name="cast")
+        C3 = g.add_node(name="Conv")
+
+        g.add_edge([C0], [C3], 123, name="e0")
+        g.add_edge([C1], [C2], 456, name="e1")
+        g.add_edge([C2], [C3], 456, name="e2")
+
+        g.canonicalize()
+        print(str(g))
+        dom_tree = g.build_dominator_tree()
+        print(str(dom_tree))
+
+        self.assertEqual(
+            str(dom_tree),
+            """Conv dominated by X\n""",
+        )
+
+    def testLevelization(self):
+        g = dataflow_graph.Graph()
+        Z = g.add_node(name="Z")
+        R = g.add_node(name="R")
+        A = g.add_node(name="A")
+        B = g.add_node(name="B")
+        C = g.add_node(name="C")
+        D = g.add_node(name="D")
+        E = g.add_node(name="E")
+        F = g.add_node(name="F")
+        G = g.add_node(name="G")
+        H = g.add_node(name="H")
+        I = g.add_node(name="I")
+        J = g.add_node(name="J")
+        K = g.add_node(name="K")
+        L = g.add_node(name="L")
+        g.add_edge([Z], [R], 0, name="e0")
+        g.add_edge([R], [A, B, C], 0, name="e1")
+        g.add_edge([A], [D], 0, name="e2")
+        g.add_edge([B], [A, D, E], 0, name="e3")
+        g.add_edge([C], [F, G], 0, name="e4")
+        g.add_edge([D], [L], 0, name="e5")
+        g.add_edge([E], [H], 0, name="e6")
+        g.add_edge([F], [I], 0, name="e7")
+        g.add_edge([G], [I, J], 0, name="e8")
+        g.add_edge([H], [K], 0, name="e9")
+        g.add_edge([I], [K], 0, name="e10")
+        g.add_edge([J], [I], 0, name="e11")
+        g.add_edge([L], [H], 0, name="e13")
+        g.canonicalize()
+        print(str(g))
+        levelization = g.build_levelization()
+        print(str(levelization))
+
+        self.assertEqual(
+            str(levelization),
+            """{Z (None): 0, R (None): 1, B (None): 2, A (None): 3, C (None): 2, D (None): 4, E (None): 3, F (None): 3, G (None): 3, L (None): 5, H (None): 6, J (None): 4, I (None): 5, K (None): 7}""",
+        )
+
+    def testReverseLevelization(self):
+        g = dataflow_graph.Graph()
+        Z = g.add_node(name="Z")
+        R = g.add_node(name="R")
+        A = g.add_node(name="A")
+        B = g.add_node(name="B")
+        C = g.add_node(name="C")
+        D = g.add_node(name="D")
+        E = g.add_node(name="E")
+        F = g.add_node(name="F")
+        G = g.add_node(name="G")
+        H = g.add_node(name="H")
+        I = g.add_node(name="I")
+        J = g.add_node(name="J")
+        K = g.add_node(name="K")
+        L = g.add_node(name="L")
+        g.add_edge([Z], [R], 0, name="e0")
+        g.add_edge([R], [A, B, C], 0, name="e1")
+        g.add_edge([A], [D], 0, name="e2")
+        g.add_edge([B], [A, D, E], 0, name="e3")
+        g.add_edge([C], [F, G], 0, name="e4")
+        g.add_edge([D], [L], 0, name="e5")
+        g.add_edge([E], [H], 0, name="e6")
+        g.add_edge([F], [I], 0, name="e7")
+        g.add_edge([G], [I, J], 0, name="e8")
+        g.add_edge([H], [K], 0, name="e9")
+        g.add_edge([I], [K], 0, name="e10")
+        g.add_edge([J], [I], 0, name="e11")
+        g.add_edge([L], [H], 0, name="e13")
+        g.canonicalize()
+        print(str(g))
+        levelization = g.build_reverse_levelization()
+        print(str(levelization))
+
+        self.assertEqual(
+            str(levelization),
+            """{K (None): 0, H (None): 1, L (None): 2, D (None): 3, A (None): 4, E (None): 2, B (None): 5, I (None): 1, F (None): 2, J (None): 2, G (None): 3, C (None): 4, R (None): 6, Z (None): 7}""",
+        )
+
+    def testOverlapInTime(self):
+        g = dataflow_graph.Graph()
+        n1 = g.add_node(name="n1")
+        n2 = g.add_node(name="n2")
+        n3 = g.add_node(name="n3")
+        n4 = g.add_node(name="n4")
+        n5 = g.add_node(name="n5")
+        n6 = g.add_node(name="n6")
+        n7 = g.add_node(name="n7")
+
+        e1 = g.add_edge([n1], [n2], 1, name="e1", mutable=False)
+        e2 = g.add_edge([n2], [n3, n5], 2, name="e2", mutable=False)
+        e3 = g.add_edge([n3], [n4], 3, name="e3", mutable=False)
+        e4 = g.add_edge([n4], [n6], 4, name="e4", mutable=False)
+        e5 = g.add_edge([n5], [n6], 5, name="e5", mutable=False)
+        e6 = g.add_edge([n6], [n7], 6, name="e6", mutable=False)
+
+        g.canonicalize()
+
+        self.assertTrue(g.can_overlap_in_time(e1, e2))
+        self.assertTrue(g.can_overlap_in_time(e2, e3))
+        self.assertTrue(g.can_overlap_in_time(e2, e5))
+        self.assertTrue(g.can_overlap_in_time(e3, e4))
+        self.assertTrue(g.can_overlap_in_time(e4, e6))
+        self.assertTrue(g.can_overlap_in_time(e5, e6))
+
+        self.assertTrue(g.can_overlap_in_time(e2, e4))
+        self.assertTrue(g.can_overlap_in_time(e3, e5))
+        self.assertTrue(g.can_overlap_in_time(e4, e5))
+
+        self.assertFalse(g.can_overlap_in_time(e1, e3))
+        self.assertFalse(g.can_overlap_in_time(e1, e5))
+        self.assertFalse(g.can_overlap_in_time(e2, e6))
+
+    def testConstraintWeightUpdates(self):
+        g = dataflow_graph.Graph()
+        A = g.add_node(name="A")
+        B = g.add_node(name="B")
+        C = g.add_node(name="C")
+        D = g.add_node(name="D")
+        E = g.add_node(name="E")
+        F = g.add_node(name="F")
+        G = g.add_node(name="G")
+        H = g.add_node(name="H")
+        I = g.add_node(name="I")
+        J = g.add_node(name="J")
+        K = g.add_node(name="K")
+        L = g.add_node(name="L")
+        M = g.add_node(name="M")
+        N = g.add_node(name="N")
+        U = g.add_node(name="U")
+        W = g.add_node(name="W", size=123)
+        g.add_edge([A], [B, C], 1, name="e1")
+        g.add_edge([B], [D], 2, name="e2")
+        g.add_edge([C], [D, N], 3, name="e3")
+        g.add_edge([D], [E, F], 4, name="e4")
+        g.add_edge([E], [G], 5, name="e5")
+        g.add_edge([F], [G, N], 6, name="e6")
+        g.add_edge([G], [H, I], 7, name="e7")
+        g.add_edge([H], [J], 8, name="e8")
+        g.add_edge([I], [J], 9, name="e9")
+        g.add_edge([J], [K, L], 10, name="e10")
+        g.add_edge([K], [M], 11, name="e11")
+        g.add_edge([L], [M], 12, name="e12")
+        g.add_edge([N], [U], 13, name="e13")
+        g.add_edge([W], [U], 134, name="e14")
+        g.canonicalize()
+
+        print(str(g))
+        fwd_levels = g.build_levelization()
+        print(str(fwd_levels))
+        self.assertEqual(
+            str(fwd_levels),
+            """{A (None): 0, B (None): 1, C (None): 1, D (None): 2, E (None): 3, F (None): 3, G (None): 4, H (None): 5, I (None): 5, J (None): 6, K (None): 7, L (None): 7, M (None): 8, N (None): 4, W (stateful_node): 0, U (None): 5, W_snk (stateful_node_sink): 1}""",
+        )
+        bwd_levels = g.build_reverse_levelization()
+        print(str(bwd_levels))
+        self.assertEqual(
+            str(bwd_levels),
+            """{M (None): 0, K (None): 1, L (None): 1, J (None): 2, H (None): 3, I (None): 3, G (None): 4, E (None): 5, U (None): 0, N (None): 1, F (None): 5, D (None): 6, B (None): 7, C (None): 7, A (None): 8, W_snk (stateful_node_sink): 0, W (stateful_node): 1}""",
+        )
+
+        g.constrain_weight_updates()
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """A (None)
+B (None)
+C (None)
+D (None)
+E (None)
+F (None)
+G (None)
+H (None)
+I (None)
+J (None)
+K (None)
+L (None)
+M (None)
+N (None)
+U (None)
+W (stateful_node)
+W_snk (stateful_node_sink)
+
+e1: A (None) -> [B (None), C (None)] size=1
+e2: B (None) -> [D (None)] size=2
+e3: C (None) -> [D (None), N (None)] size=3
+e4: D (None) -> [E (None), F (None)] size=4
+e5: E (None) -> [G (None)] size=5
+e6: F (None) -> [G (None), N (None)] size=6
+e7: G (None) -> [H (None), I (None)] size=7
+e8: H (None) -> [J (None)] size=8
+e9: I (None) -> [J (None)] size=9
+e10: J (None) -> [K (None), L (None)] size=10
+e11: K (None) -> [M (None)] size=11
+e12: L (None) -> [M (None)] size=12
+e13: N (None) -> [U (None)] size=13
+e14: W (stateful_node) -> [U (None), W_snk (stateful_node_sink)] size=257
+U_forced_early: U (None) -> [J (None)] size=0
+""",
+        )
+
+    def testConstraintWeightUpdatesNoSolution(self):
+        g = dataflow_graph.Graph()
+        A = g.add_node(name="A")
+        B = g.add_node(name="B")
+        C = g.add_node(name="C")
+        D = g.add_node(name="D")
+        E = g.add_node(name="E")
+        F = g.add_node(name="F")
+        G = g.add_node(name="G")
+        H = g.add_node(name="H")
+        I = g.add_node(name="I")
+        J = g.add_node(name="J")
+        K = g.add_node(name="K")
+        L = g.add_node(name="L")
+        M = g.add_node(name="M")
+        W = g.add_node(name="W", size=123)
+        g.add_edge([A], [B, C], 1, name="e1")
+        g.add_edge([B], [D], 2, name="e2")
+        g.add_edge([C], [D], 3, name="e3")
+        g.add_edge([D], [E, F], 4, name="e4")
+        g.add_edge([E], [G], 5, name="e5")
+        g.add_edge([F], [G], 6, name="e6")
+        g.add_edge([G], [H, I], 7, name="e7")
+        g.add_edge([H], [J], 8, name="e8")
+        g.add_edge([I], [J], 9, name="e9")
+        g.add_edge([J], [K, L], 10, name="e10")
+        g.add_edge([K], [M], 11, name="e11")
+        g.add_edge([L], [M], 12, name="e12")
+        g.add_edge([W], [M], 0, name="e13")
+        g.canonicalize()
+
+        print(str(g))
+        fwd_levels = g.build_levelization()
+        print(str(fwd_levels))
+        self.assertEqual(
+            str(fwd_levels),
+            """{A (None): 0, B (None): 1, C (None): 1, D (None): 2, E (None): 3, F (None): 3, G (None): 4, H (None): 5, I (None): 5, J (None): 6, K (None): 7, L (None): 7, W (stateful_node): 0, M (None): 8, W_snk (stateful_node_sink): 1}""",
+        )
+        bwd_levels = g.build_reverse_levelization()
+        print(str(bwd_levels))
+        self.assertEqual(
+            str(bwd_levels),
+            """{M (None): 0, K (None): 1, L (None): 1, J (None): 2, H (None): 3, I (None): 3, G (None): 4, E (None): 5, F (None): 5, D (None): 6, B (None): 7, C (None): 7, A (None): 8, W_snk (stateful_node_sink): 0, W (stateful_node): 1}""",
+        )
+
+        g.constrain_weight_updates()
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """A (None)
+B (None)
+C (None)
+D (None)
+E (None)
+F (None)
+G (None)
+H (None)
+I (None)
+J (None)
+K (None)
+L (None)
+M (None)
+W (stateful_node)
+W_snk (stateful_node_sink)
+
+e1: A (None) -> [B (None), C (None)] size=1
+e2: B (None) -> [D (None)] size=2
+e3: C (None) -> [D (None)] size=3
+e4: D (None) -> [E (None), F (None)] size=4
+e5: E (None) -> [G (None)] size=5
+e6: F (None) -> [G (None)] size=6
+e7: G (None) -> [H (None), I (None)] size=7
+e8: H (None) -> [J (None)] size=8
+e9: I (None) -> [J (None)] size=9
+e10: J (None) -> [K (None), L (None)] size=10
+e11: K (None) -> [M (None)] size=11
+e12: L (None) -> [M (None)] size=12
+e13: W (stateful_node) -> [M (None), W_snk (stateful_node_sink)] size=123
+""",
+        )
+
+    def test_find_nodes_only_name(self) -> None:
+        g = dataflow_graph.Graph()
+
+        g.add_node(name="x_test_in_middle_x")
+        g.add_node(name="test_in_front")
+        g.add_node(name=None)
+        g.add_node(name="back_test")
+        g.add_node(name="middle_te_asterisk_st_end")
+        g.add_node(name="test")
+
+        # Testing finding the Node with name=None
+        test = g.find_nodes("3")
+        self.assertTrue(self.compare_item_lists(test, [dataflow_graph.Node("3")]))
+
+        test = g.find_node("3")
+        self.assertTrue(self.compare_items(test, dataflow_graph.Node("3")))
+
+        test = g.find_nodes(name="test")
+        self.assertTrue(self.compare_item_lists(test, [dataflow_graph.Node("test")]))
+
+        test = g.find_nodes(name="*test")
+        self.assertTrue(
+            self.compare_item_lists(
+                test, [dataflow_graph.Node("back_test"), dataflow_graph.Node("test")]
+            )
+        )
+
+        test = g.find_nodes(name="test*")
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [dataflow_graph.Node("test_in_front"), dataflow_graph.Node("test")],
+            )
+        )
+
+        test = g.find_nodes(name="*test*")
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.Node("x_test_in_middle_x"),
+                    dataflow_graph.Node("test_in_front"),
+                    dataflow_graph.Node("back_test"),
+                    dataflow_graph.Node("test"),
+                ],
+            )
+        )
+
+        test = g.find_nodes(name="*te*st*")
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.Node("x_test_in_middle_x"),
+                    dataflow_graph.Node("test_in_front"),
+                    dataflow_graph.Node("back_test"),
+                    dataflow_graph.Node("middle_te_asterisk_st_end"),
+                    dataflow_graph.Node("test"),
+                ],
+            )
+        )
+
+        test = g.find_nodes(name="*te*st*", max_nodes=4)
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.Node("x_test_in_middle_x"),
+                    dataflow_graph.Node("test_in_front"),
+                    dataflow_graph.Node("back_test"),
+                    dataflow_graph.Node("middle_te_asterisk_st_end"),
+                ],
+            )
+        )
+
+        with self.assertRaises(ValueError):
+            g.find_nodes(op_type="weight")
+
+        with self.assertRaises(ValueError):
+            g.find_node(op_type="weight")
+
+    def test_find_nodes_all_params(self) -> None:
+        g = dataflow_graph.Graph()
+
+        g.add_node(name="x_test_in_middle_x", op_type="weight")
+        g.add_node(name="test_in_front", op_type="weight")
+        g.add_node(name="back_test", op_type="weight")
+        g.add_node(name=None, op_type="weight")
+        g.add_node(name="middle_te_asterisk_st_end", op_type="turing::copy")
+        g.add_node(name="test", op_type="turing::copy")
+        g.add_node(name="this_test_shouldnt_show_up", op_type="turing::copy")
+
+        test = g.find_nodes(name="test", op_type="turing::copy")
+        self.assertTrue(
+            self.compare_item_lists(
+                test, [dataflow_graph.Node(name="test", op_type="turing::copy")]
+            )
+        )
+
+        test = g.find_nodes(name="*test", op_type="weight")
+        self.assertTrue(
+            self.compare_item_lists(
+                test, [dataflow_graph.Node(name="back_test", op_type="weight")]
+            )
+        )
+
+        test = g.find_nodes(name="test*", op_type="weight")
+        self.assertTrue(
+            self.compare_item_lists(
+                test, [dataflow_graph.Node(name="test_in_front", op_type="weight")]
+            )
+        )
+
+        test = g.find_nodes(name="*test*", op_type="turing::copy", max_nodes=1)
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.Node(name="test", op_type="turing::copy"),
+                ],
+            )
+        )
+
+        test = g.find_nodes(name="*te*st*", op_type="turing::copy", max_nodes=2)
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.Node(
+                        name="middle_te_asterisk_st_end", op_type="turing::copy"
+                    ),
+                    dataflow_graph.Node(name="test", op_type="turing::copy"),
+                ],
+            )
+        )
+
+    def test_find_edges_with_name(self) -> None:
+        g = dataflow_graph.Graph()
+
+        A = g.add_node(name="a")
+        B = g.add_node(name="b")
+        C = g.add_node(name="c")
+        D = g.add_node(name="d")
+        E = g.add_node(name="e")
+        F = g.add_node(name="f")
+        G = g.add_node(name="g")
+
+        g.add_edge(
+            [A],
+            [B],
+            123,
+            name="test_in_front",
+            mem_space="mem_space",
+            tile_id="tile_id",
+            group_id="group_id",
+        )
+        g.add_edge(
+            [A],
+            [C],
+            456,
+            name="test_in_front2",
+            mem_space="mem_space",
+            tile_id="tile_id",
+            group_id="group_id",
+        )
+        g.add_edge([B], [D], 789, name="middle_test_middle", group_id="group2")
+        g.add_edge([C], [D], 789, name="middle_test_middle2", group_id="group2")
+        g.add_edge([D], [E, F], 1034, name="e5")
+        g.add_edge([E], [G], 1045, name="e6")
+        g.add_edge([F], [G], 1089, name="e8")
+
+        test = g.find_edges(
+            name="test*", mem_space="mem_space", tile_id="tile_id", group_id="group_id"
+        )
+        self.assertTrue(
+            test,
+            [
+                dataflow_graph.MultiSourceEdge(
+                    [A],
+                    [B],
+                    123,
+                    name="test_in_front",
+                    mem_space="mem_space",
+                    tile_id="tile_id",
+                    group_id="group_id",
+                ),
+                dataflow_graph.MultiSourceEdge(
+                    [A],
+                    [C],
+                    456,
+                    name="test_in_front2",
+                    mem_space="mem_space",
+                    tile_id="tile_id",
+                    group_id="group_id",
+                ),
+            ],
+        )
+
+        test = g.find_edges(
+            name="test*",
+            mem_space="mem_space",
+            tile_id="tile_id",
+            group_id="group_id",
+            max_edges=1,
+        )
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.MultiSourceEdge(
+                        [A],
+                        [B],
+                        123,
+                        name="test_in_front",
+                        mem_space="mem_space",
+                        tile_id="tile_id",
+                        group_id="group_id",
+                    ),
+                ],
+            )
+        )
+
+        test = g.find_edge(
+            name="test*",
+            mem_space="mem_space",
+            tile_id="tile_id",
+            group_id="group_id",
+        )
+        self.assertTrue(
+            self.compare_items(
+                test,
+                dataflow_graph.MultiSourceEdge(
+                    [A],
+                    [B],
+                    123,
+                    name="test_in_front",
+                    mem_space="mem_space",
+                    tile_id="tile_id",
+                    group_id="group_id",
+                ),
+            )
+        )
+
+        test = g.find_edges(group_id="group2")
+        self.assertTrue(
+            self.compare_item_lists(
+                test,
+                [
+                    dataflow_graph.MultiSourceEdge(
+                        [B],
+                        [D],
+                        789,
+                        name="middle_test_middle",
+                        group_id="group2",
+                    ),
+                    dataflow_graph.MultiSourceEdge(
+                        [C],
+                        [D],
+                        789,
+                        name="middle_test_middle2",
+                        group_id="group2",
+                    ),
+                ],
+            )
+        )

--- a/tests/defragmenter_test.py
+++ b/tests/defragmenter_test.py
@@ -1,0 +1,46 @@
+import unittest
+
+from olla import dataflow_graph, defragmenter
+
+
+class DefragmenterTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testNoOverlap(self):
+        defrag = defragmenter.Defragmenter()
+        spans = {}
+        spans[dataflow_graph.Edge(None, [], 23, "a")] = (0, 10)
+        spans[dataflow_graph.Edge(None, [], 25, "b")] = (11, 13)
+        layout = defrag.ComputeBestLayout(spans)
+        l = [(e.name, a) for e, a in layout.items()]
+        self.assertEqual(l, [("a", 0.0), ("b", 0.0)])
+
+    def testOverlap(self):
+        defrag = defragmenter.Defragmenter()
+        spans = {}
+        spans[dataflow_graph.Edge(None, [], 23, "a")] = (0, 10)
+        spans[dataflow_graph.Edge(None, [], 25, "b")] = (9, 13)
+        layout = defrag.ComputeBestLayout(spans)
+        l = [(e.name, a) for e, a in layout.items()]
+        self.assertEqual(l, [("a", 0.0), ("b", 23.0)])
+
+    def testMixed(self):
+        defrag = defragmenter.Defragmenter()
+        spans = {}
+        spans[dataflow_graph.Edge(None, [], 23, "a")] = (0, 10)
+        spans[dataflow_graph.Edge(None, [], 25, "b")] = (9, 13)
+        spans[dataflow_graph.Edge(None, [], 27, "c")] = (12, 15)
+        layout = defrag.ComputeBestLayout(spans)
+        l = [(e.name, a) for e, a in layout.items()]
+        self.assertEqual(l, [("a", 0.0), ("b", 27.0), ("c", 0.0)])
+
+    def testRandomOrderMixed(self):
+        defrag = defragmenter.Defragmenter()
+        spans = {}
+        spans[dataflow_graph.Edge(None, [], 27, "c")] = (12, 15)
+        spans[dataflow_graph.Edge(None, [], 23, "a")] = (0, 10)
+        spans[dataflow_graph.Edge(None, [], 25, "b")] = (9, 13)
+        layout = defrag.ComputeBestLayout(spans)
+        l = [(e.name, a) for e, a in layout.items()]
+        self.assertEqual(l, [("c", 25.0), ("a", 25.0), ("b", 0.0)])

--- a/tests/fx_optimizer_test.py
+++ b/tests/fx_optimizer_test.py
@@ -1,0 +1,80 @@
+import unittest
+
+import torch
+
+from olla.torch import fx_optimizer, torch_graph_importer
+
+
+class MaxCutTest(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def testSimpleModule(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(4, 5)
+                self.linear2 = torch.nn.Linear(4, 5)
+
+            def forward(self, x):
+                return self.linear1(x) + self.linear2(x)
+
+        module = SimpleModule()
+        importer = torch_graph_importer.TorchGraphImporter()
+        input_tensor = torch.randn((3, 4))
+        (
+            g,
+            pytorch_node_order,
+            fx_graph,
+            fx_to_df_map,
+        ) = importer.import_via_aotautograd(
+            module, input_tensor, return_node_ordering=True, return_fx_graph=True
+        )
+        self.assertTrue(g.is_valid())
+
+        fx_graph.recompile()
+        initial_result = fx_graph.forward(
+            (input_tensor,),
+            params=dict(module.named_parameters()),
+            buffers=dict(module.named_buffers()),
+        )
+        print(initial_result)
+
+        node_order = str([node for node in fx_graph.graph.nodes])
+        # print(f"NODES INITIAL = {node_order}", flush=True)
+        self.assertEqual(
+            node_order,
+            "[args_1, params_1, params_2, params_3, params_4, t, addmm, t_1, addmm_1, add, sum_1, ones_like, expand, t_2, mm, t_3, sum_2, view, t_4, t_5, mm_1, t_6, sum_3, view_1, t_7, output]",
+        )
+
+        nodes = [node for node in fx_graph.graph.nodes]
+        tmp1 = nodes[5]
+        tmp2 = nodes[6]
+        nodes[5] = nodes[7]
+        nodes[6] = nodes[8]
+        nodes[7] = tmp1
+        nodes[8] = tmp2
+
+        prev = fx_graph.graph._root
+        for i in range(len(nodes)):
+            n = nodes[i]
+            if prev.next != n:
+                prev.append(n)
+            prev = prev.next
+
+        node_order = str([node for node in fx_graph.graph.nodes])
+        # print(f"NODES FINAL = {node_order}", flush=True)
+        self.assertEqual(
+            node_order,
+            "[args_1, params_1, params_2, params_3, params_4, t_1, addmm_1, t, addmm, add, sum_1, ones_like, expand, t_2, mm, t_3, sum_2, view, t_4, t_5, mm_1, t_6, sum_3, view_1, t_7, output]",
+        )
+
+        fx_graph.graph.lint()
+        fx_graph.recompile()
+        final_result = fx_graph.forward(
+            (input_tensor,),
+            params=dict(module.named_parameters()),
+            buffers=dict(module.named_buffers()),
+        )
+        print(final_result)
+        self.assertEqual(initial_result, final_result)

--- a/tests/fx_profiler_test.py
+++ b/tests/fx_profiler_test.py
@@ -1,0 +1,53 @@
+import time
+import unittest
+
+import torch
+import torchvision
+from olla.torch import torch_graph_importer
+
+
+class FXProfilterTest(unittest.TestCase):
+    def testAlexNet(self):
+        batch_size = 32
+        model = torchvision.models.alexnet()
+
+        device = "cpu"
+        if torch.cuda.is_available():
+            device = "cuda"
+
+        inputs = (torch.randn((batch_size, 3, 224, 224), device=device),)
+
+        model.eval()
+        model.to(device)
+
+        model.forward(inputs[0])
+        if device == "cuda":
+            torch.cuda.synchronize()
+        start = time.time()
+        for _ in range(10):
+            model.forward(inputs[0])
+        if device == "cuda":
+            torch.cuda.synchronize()
+        stop = time.time()
+        pt_time = (stop - start) / 10
+        print(f"PT TIME = {pt_time}")
+
+        importer = torch_graph_importer.TorchGraphImporter()
+        g, pt_node_order, fx_trace, _ = importer.import_via_aotautograd(
+            model,
+            *inputs,
+            optimizer=None,
+            mode="eval",
+            return_fx_graph=True,
+            profile=["time"],
+        )
+
+        profile_time = 0
+        for n in g.nodes.values():
+            profile_time += n.time
+        print(f"PROFILE TIME = {profile_time}")
+
+        # The profiler accuracy is not good enough at the moment.
+        # self.assertLessEqual(
+        #    abs(pt_time - profile_time) / max(pt_time, profile_time), 0.1
+        # )

--- a/tests/ilp_solver_test.py
+++ b/tests/ilp_solver_test.py
@@ -1,0 +1,56 @@
+import unittest
+
+from olla import ilp_solver
+
+
+class ILPSolverTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testSimpleProblem(self):
+        solver = ilp_solver.ILPSolver()
+        x1 = solver.create_integer_var("x1", -10, 10)
+        x2 = solver.create_real_var("x2")
+        solver.add_constraint(x1 + 3 * x2 >= 4)
+        solver.add_constraint(10 * x1 + 3 * x2 <= 40)
+
+        # Minimize the objective
+        solver.set_objective_function(x1**2 + 2 * x2, maximize=False)
+        s = solver.solve()
+        self.assertAlmostEqual(s[x1], 0.0)
+        self.assertAlmostEqual(s[x2], 1.3333333333)
+
+        # Maximize the objective
+        solver.set_objective_function(x1**2 + 2 * x2, maximize=True)
+        s = solver.solve()
+        self.assertAlmostEqual(s[x1], -10.0)
+        self.assertAlmostEqual(s[x2], 46.66666666666667)
+
+    def testBounds(self):
+        solver = ilp_solver.ILPSolver()
+        x1 = solver.create_integer_var("x1", 7, 7)
+        x2 = solver.create_integer_var("x2")
+        solver.add_constraint(x2 <= 13)
+        solver.set_objective_function(x1 + x2)
+        s = solver.solve()
+        self.assertAlmostEqual(s[x1], 7.0)
+        self.assertAlmostEqual(s[x2], 13.0)
+
+    def testWrite(self):
+        solver = ilp_solver.ILPSolver()
+        x1 = solver.create_integer_var("x1", -10, 10)
+        x2 = solver.create_real_var("x2")
+        solver.add_constraint(x1 + 3 * x2 >= 4)
+        solver.add_constraint(10 * x1 + 3 * x2 <= 40)
+        solver.set_objective_function(x1**2 + 2 * x2, maximize=False)
+        solver.write("simple_pb")
+
+    def testGurobi(self):
+        solver = ilp_solver.ILPSolver(solver="GUROBI")
+        x1 = solver.create_integer_var("x1", 7, 7)
+        x2 = solver.create_integer_var("x2")
+        solver.add_constraint(x2 <= 13)
+        solver.set_objective_function(x1 + x2)
+        s = solver.solve()
+        self.assertAlmostEqual(s[x1], 7.0)
+        self.assertAlmostEqual(s[x2], 13.0)

--- a/tests/max_cut_test.py
+++ b/tests/max_cut_test.py
@@ -1,0 +1,55 @@
+import unittest
+
+from olla import dataflow_graph, max_cut
+
+
+class MaxCutTest(unittest.TestCase):
+    def setUp(self):
+        self.g = dataflow_graph.Graph()
+        IN = self.g.add_node(name="IN")
+        A = self.g.add_node(name="A")
+        B = self.g.add_node(name="B")
+        C = self.g.add_node(name="C")
+        D = self.g.add_node(name="D")
+        E = self.g.add_node(name="E")
+        F = self.g.add_node(name="F")
+        self.g.add_edge([IN], [A, B], size=2, name="IN->AB")
+        self.g.add_edge([A], [C], size=100, name="A->C")
+        self.g.add_edge([C], [E], size=5, name="C->E")
+        self.g.add_edge([B], [D], size=200, name="B->D")
+        self.g.add_edge([D], [F], size=10, name="D->F")
+
+        self.g.canonicalize()
+        self.assertTrue(self.g.is_valid())
+
+    def testSimpleGraph(self):
+        mc = max_cut.MaxCut(self.g, debug=True)
+        cut_size, cut = mc.LocateCut()
+        cut = [t.name for t in cut]
+        print(str(cut))
+        self.assertEqual(315, cut_size)
+        self.assertEqual(cut, ["C", "D"])
+
+    def testUserSchedule(self):
+        mc = max_cut.MaxCut(self.g, debug=True)
+
+        user_schedule = {
+            self.g.nodes["C"]: 3,
+            self.g.nodes["B"]: 4,
+        }
+        cut_size, cut = mc.LocateCut(user_schedule=user_schedule)
+        cut = [t.name for t in cut]
+        print(str(cut))
+        self.assertEqual(315, cut_size)  # Wrong cost
+        self.assertEqual(cut, ["C", "D"])
+
+        user_schedule = {
+            self.g.nodes["B"]: 4,
+            self.g.nodes["E"]: 3,
+        }
+        cut_size, cut = mc.LocateCut(user_schedule=user_schedule)
+        cut = [t.name for t in cut]
+        print(str(cut))
+        # The cut through D is disabled since E is an output and must reside in partition 0
+        self.assertEqual(107, cut_size)
+        self.assertEqual(cut, ["IN", "C"])

--- a/tests/memory_planner_test.py
+++ b/tests/memory_planner_test.py
@@ -1,0 +1,82 @@
+import unittest
+
+from olla import memory_planner
+from olla.native_graphs import (
+    control_dep_graph,
+    diamond_graph,
+    multi_fanin_output_graph,
+    shared_multi_fanin_output_graph,
+    simple_graph,
+)
+
+
+class MemoryPlannerTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testNonFragmentation(self):
+        g = simple_graph.graph
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=1024)
+
+        self.assertEqual(summary["peak_mem_usage"], 70)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+    def testSimpleGraph(self):
+        g = simple_graph.graph
+
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=1024)
+
+        self.assertEqual(summary["peak_mem_usage"], 70)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+    def testDiamondGraph(self):
+        g = diamond_graph.graph
+
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=1024)
+
+        self.assertEqual(summary["peak_mem_usage"], 130)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+    def testControlDepGraph(self):
+        g = control_dep_graph.graph
+
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=1024)
+
+        self.assertEqual(summary["peak_mem_usage"], 150)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+    def testControlDepGraphWithSpills(self):
+        g = control_dep_graph.graph
+
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=120)
+
+        self.assertEqual(summary["peak_mem_usage"], 120)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 120)
+
+    def testMultiFaninOutputGraph(self):
+        g = multi_fanin_output_graph.graph
+
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=110)
+
+        self.assertEqual(summary["peak_mem_usage"], 110)
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+    def testSharedMultiFaninOutputGraph(self):
+        g = shared_multi_fanin_output_graph.graph
+
+        p = memory_planner.MemoryPlanner()
+        summary = p.plan(g, mem_limit=1024)
+
+        self.assertEqual(summary["peak_mem_usage"], 60)
+        self.assertEqual(summary["total_data_swapped"], 0)

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -1,0 +1,295 @@
+import unittest
+
+from olla import scheduler, utils
+from olla.native_graphs import (
+    control_dep_graph,
+    diamond_graph,
+    multi_fanin_output_graph,
+    pathological_graph,
+    shared_multi_fanin_output_graph,
+    simple_graph,
+)
+
+
+class SchedulerTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testNonFragmentation(self):
+        g = simple_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            max_spills=0,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 70)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: ([1], [2], []) ",
+                "2: ([2], [], []) ",
+                "3: ([2], [3, 4], []) ",
+                "4: ([4], [], []) ",
+            ],
+        )
+
+    def testSimpleGraph(self):
+        g = simple_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+            max_spills=0,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 70)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: (['2@0'], [3], []) ",
+                "2: (['3@10'], [], []) ",
+                "3: (['3@40'], [4], []) ",
+                "4: (['4@0'], [], []) ",
+            ],
+        )
+
+    def testDiamondGraph(self):
+        g = diamond_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+            max_spills=0,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 130)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: (['1@20'], [2], []) ",
+                "2: (['2@0'], [3, 4, 5], []) ",
+                "3: (['2@60'], [3], []) ",
+                "4: (['3@20'], [4], []) ",
+                "5: (['4@80'], [5, 6], []) ",
+                "6: (['5@20'], [6], []) ",
+                "7: (['6@10'], [], []) ",
+            ],
+        )
+
+    def testControlDepGraph(self):
+        g = control_dep_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+            max_spills=0,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 150)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: (['1@30'], [2], []) ",
+                "2: (['2@130'], [3], []) ",
+                "3: (['2@0'], [3, 4], []) ",
+                "4: (['4@110'], [5], []) ",
+                "5: (['5@0'], [6], []) ",
+                "6: (['3@50'], [4, 5, 6], []) ",
+                "7: (['6@110'], [], []) ",
+                "8: (['3[ctrl]'], [4, 5], []) ",
+            ],
+        )
+
+    def testControlDepGraphWithSpills(self):
+        g = control_dep_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+            max_spills=180,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 120)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 160)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: (['1@0'], [2], []) ",
+                "2: (['2@70'], [], ['4@40']) ",
+                "3: (['2@40'], [3], []) ",
+                "4: (['3@0'], [4, 5], []) ",
+                "5: (['5@70'], [6], []) ",
+                "6: (['4@60'], [], ['6@10']) ",
+                "7: (['6@0'], [], []) ",
+                "8: (['4[ctrl]'], [5], []) ",
+            ],
+        )
+
+    def testMultiFaninOutputGraph(self):
+        g = multi_fanin_output_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+            max_spills=0,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 110)
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: (['1@0'], [2], []) ",
+                "2: (['1@90'], [2, 3, 4], []) ",
+                "3: (['2@20'], [3], []) ",
+                "4: (['3@50'], [4, 5], []) ",
+                "5: (['4@0'], [5], []) ",
+            ],
+        )
+
+    def testSharedMultiFaninOutputGraph(self):
+        g = shared_multi_fanin_output_graph.graph
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            account_for_fragmentation=True,
+            defrag=True,
+            max_spills=0,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 60)
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "1: (['3@0'], [4], []) ",
+                "2: (['3@40'], [4], []) ",
+                "allocate_3: (['1@10'], [2, 3, 4, 5], []) ",
+                "B_3: (['4[ctrl]'], [5], []) ",
+                "C_3: (['4[ctrl]'], [5], []) ",
+            ],
+        )
+
+    def testPathologicalCase(self):
+        g = pathological_graph.graph
+
+        user_schedule = {
+            "M0": 1,
+            "M1": 2,
+            "M2": 4,
+            "M3": 5,
+            "M4": 7,
+            "M5": 8,
+            "M6": 11,
+            "M7": 14,
+            "F0": 10,
+            "F1": 3,
+            "F2": 13,
+            "F3": 6,
+            "F4": 16,
+            "F5": 9,
+            "F6": 12,
+            "F7": 15,
+        }
+
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=10,
+            allow_swaps=False,
+            account_for_fragmentation=True,
+            defrag=True,
+            user_schedule=user_schedule,
+        )
+
+        self.assertEqual(summary["required_memory"], 10)
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "T0: (['1@9'], [2, 3, 4, 5, 6, 7, 8, 9, 10], []) ",
+                "T1: (['2@0'], [3], []) ",
+                "T2: (['4@0'], [5, 6, 7, 8, 9, 10, 11, 12, 13], []) ",
+                "T3: (['5@1'], [6], []) ",
+                "T4: (['7@1'], [8, 9, 10, 11, 12, 13, 14, 15, 16], []) ",
+                "T5: (['8@2'], [9], []) ",
+                "T6: (['11@2'], [12], []) ",
+                "T7: (['14@2'], [15], []) ",
+            ],
+        )

--- a/tests/simulator_test.py
+++ b/tests/simulator_test.py
@@ -1,0 +1,162 @@
+import unittest
+
+from olla import simulator
+from olla.native_graphs import (
+    control_dep_graph,
+    diamond_graph,
+    graph_with_two_weights,
+    multi_fanin_output_graph,
+    pathological_graph,
+    shared_multi_fanin_output_graph,
+    simple_graph,
+)
+
+
+class SimulatorTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testSimpleGraph(self):
+        g = simple_graph.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 70)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep, [("A", 10), ("B", 60), ("C", 50), ("D", 70), ("E", 40)]
+        )
+
+    def testDiamondGraph(self):
+        g = diamond_graph.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 150)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep,
+            [
+                ("A", 10),
+                ("B", 60),
+                ("C", 110),
+                ("D", 130),
+                ("E", 150),
+                ("F", 120),
+                ("G", 10),
+            ],
+        )
+
+    def testControlDepGraph(self):
+        g = control_dep_graph.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 150)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep,
+            [
+                ("A", 10),
+                ("B", 60),
+                ("C", 110),
+                ("D", 130),
+                ("E", 150),
+                ("F", 120),
+                ("G", 10),
+            ],
+        )
+
+    def testMultiFaninOutputGraph(self):
+        g = multi_fanin_output_graph.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 120)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep, [("A", 30), ("B", 60), ("C", 100), ("D", 120), ("E", 90)]
+        )
+
+    def testSharedMultiFaninOutputGraph(self):
+        g = shared_multi_fanin_output_graph.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 60)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep,
+            [("A", 30), ("allocate_3", 60), ("B", 60), ("C", 50), ("D", 30)],
+        )
+
+    def testPathologicalCase(self):
+        g = pathological_graph.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 42)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep,
+            [
+                ("M0", 1),
+                ("M1", 10),
+                ("M2", 11),
+                ("M3", 19),
+                ("M4", 20),
+                ("M5", 27),
+                ("M6", 35),
+                ("M7", 42),
+                ("F0", 42),
+                ("F1", 41),
+                ("F2", 32),
+                ("F3", 31),
+                ("F4", 23),
+                ("F5", 22),
+                ("F6", 15),
+                ("F7", 7),
+            ],
+        )
+
+    def testGraphWithTwoWeights(self):
+        g = graph_with_two_weights.graph
+        g.unused_weight_size = 0
+        print(str(g))
+        s = simulator.Simulator(g)
+        topo_order = g.compute_topological_ordering()
+        peak_mem_usage, mem_per_timestep = s.Simulate(topo_order)
+        self.assertEqual(peak_mem_usage, 524)
+        mem_per_timestep = [(n.name, mem) for n, mem in mem_per_timestep]
+        print(str(mem_per_timestep))
+        self.assertEqual(
+            mem_per_timestep,
+            [
+                ("WEIGHT1", 123),
+                ("WEIGHT2", 444),
+                ("INPUT", 454),
+                ("OPERATOR1", 484),
+                ("OPERATOR2", 524),
+                ("OUTPUT", 494),
+                ("WEIGHT1_snk", 444),
+                ("WEIGHT2_snk", 321),
+            ],
+        )

--- a/tests/spill_profiler_test.py
+++ b/tests/spill_profiler_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+import torch
+
+from olla.native_graphs import graph_with_gradients
+from olla.torch import spill_profiler
+
+
+class SpillProfilterTest(unittest.TestCase):
+    def testBasic(self):
+        g = graph_with_gradients.graph
+        profiler = spill_profiler.SpillProfiler(g, warm_up_iters=1, profile_iters=10)
+        profile = profiler.benchmark_all()
+
+        rslt = {e.name: time for e, time in profile.items()}
+
+        if torch.cuda.is_available():
+            print(
+                f"Warning: stats collected on actual gpu: {torch.cuda.get_device_properties('cuda')}"
+            )
+
+        print(str(rslt))
+        self.assertEqual(
+            rslt,
+            {
+                "ACTIVATION1": 1.0002e-05,
+                "WEIGHT_REF1": 1.00246e-05,
+                "ACTIVATION2": 1.0006e-05,
+                "WEIGHT_REF2": 1.0064200000000001e-05,
+                "OUTPUT_EDGE": 1.001e-05,
+                "PROPAGATE_G1": 1.0069000000000001e-05,
+                "PROPAGATE_G2": 1.01086e-05,
+                "UPDATE_W1": 1.01134e-05,
+                "UPDATE_W2": 1.0153000000000001e-05,
+            },
+        )

--- a/tests/torch_graph_importer_test.py
+++ b/tests/torch_graph_importer_test.py
@@ -1,0 +1,1145 @@
+import os
+import unittest
+
+import torch
+import torch.fx
+from olla import dataflow_graph
+from olla.torch import torch_graph_importer
+
+del os.environ["LD_LIBRARY_PATH"]
+
+
+class TorchGraphImporterTest(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+        self.maxDiff = None
+
+    def run_tests(
+        self,
+        model,
+        *inputs,
+        mode="eval",
+        methods=None,
+        optimizer=None,
+        test_name="test",
+    ):
+        if methods is None:
+            methods = ["aotautograd"]
+
+        for method in methods:
+            with self.subTest():
+                g = self.importer.import_from_torch(
+                    model,
+                    *inputs,
+                    mode=mode,
+                    method=method,
+                    optimizer=optimizer,
+                )
+                self.assertTrue(g.is_valid())
+                # g.dump(f"/tmp/{test_name}.{method}.dot")
+
+    def testSimpleGraph(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.rand(3, 4))
+                self.linear = torch.nn.Linear(4, 5)
+
+            def forward(self, x):
+                return self.linear(x + self.param).clamp(min=0.0, max=1.0)
+
+        simple_module = SimpleModule()
+        input_shape = (3, 4)
+
+        # TODO: currently, the default for inference is fx, and for training is aotautograd
+        # It may be better to set aotautograd default for both inference and training
+        with self.subTest("default"):
+            g = self.importer.import_from_torch(simple_module, torch.randn(input_shape))
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/simple.fx.opt4ml.dot")
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (weight) [48]"]
+\tadd [label="add (call_function)"]
+\tlinear_weight [label="linear_weight (weight) [80]"]
+\tlinear_bias [label="linear_bias (weight) [20]"]
+\tlinear [label="linear (call_function)"]
+\tclamp [label="clamp (call_method)"]
+\tx -> add [label=48]
+\tparam -> add [label=0]
+\tadd -> linear [label=48]
+\tlinear_weight -> linear [label=0]
+\tlinear_bias -> linear [label=0]
+\tlinear -> clamp [label=60]
+}
+""",
+            )
+
+            g.canonicalize()
+            self.assertTrue(g.is_valid())
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (stateful_node)"]
+\tadd [label="add (call_function)"]
+\tlinear_weight [label="linear_weight (stateful_node)"]
+\tlinear_bias [label="linear_bias (stateful_node)"]
+\tlinear [label="linear (call_function)"]
+\tclamp [label="clamp (call_method)"]
+\tparam_snk [label="param_snk (stateful_node_sink)"]
+\tlinear_weight_snk [label="linear_weight_snk (stateful_node_sink)"]
+\tlinear_bias_snk [label="linear_bias_snk (stateful_node_sink)"]
+\tx -> add [label=48]
+\tparam -> add [label=48]
+\tparam -> param_snk [label=48]
+\tadd -> linear [label=48]
+\tlinear_weight -> linear [label=80]
+\tlinear_weight -> linear_weight_snk [label=80]
+\tlinear_bias -> linear [label=20]
+\tlinear_bias -> linear_bias_snk [label=20]
+\tlinear -> clamp [label=60]
+}
+""",
+            )
+
+        with self.subTest("aotautograd"):
+            g, _ = self.importer.import_via_aotautograd(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/simple.aotautograd.opt4ml.dot")
+
+        with self.subTest("functorch"):
+            g = self.importer.import_via_functorch(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/simple.functorch.opt4ml.dot")
+
+        with self.subTest("acc_tracer"):
+            # FIXME: check why batchnorm weights have 0 tensor sizes in the graph
+            g = self.importer.import_via_acc_tracer(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/simple.acc_tracer.opt4ml.dot")
+
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (weight) [48]"]
+\tadd_1 [label="add_1 (call_function)"]
+\tlinear_weight [label="linear_weight (weight) [80]"]
+\tlinear_bias [label="linear_bias (weight) [20]"]
+\tlinear_1 [label="linear_1 (call_function)"]
+\tclamp_1 [label="clamp_1 (call_function)"]
+\tx -> add_1 [label=48]
+\tparam -> add_1 [label=0]
+\tadd_1 -> linear_1 [label=48]
+\tlinear_weight -> linear_1 [label=0]
+\tlinear_bias -> linear_1 [label=0]
+\tlinear_1 -> clamp_1 [label=60]
+}
+""",
+            )
+
+    def testWeightsWithCast(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.rand(3, 4))
+
+            def forward(self, x):
+                return (x + self.param.float()).clamp(min=0.0, max=1.0)
+
+        simple_module = SimpleModule()
+        input_shape = (3, 4)
+
+        with self.subTest("vanilla_fx"):
+            g = self.importer.import_via_fx(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/weightswithcast.fx.opt4ml.dot")
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (weight) [48]"]
+\tfloat_1 [label="float_1 (call_method)"]
+\tadd [label="add (call_function)"]
+\tclamp [label="clamp (call_method)"]
+\tx -> add [label=48]
+\tparam -> float_1 [label=0]
+\tfloat_1 -> add [label=48]
+\tadd -> clamp [label=48]
+}
+""",
+            )
+
+            g.canonicalize()
+            self.assertTrue(g.is_valid())
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (stateful_node)"]
+\tfloat_1 [label="float_1 (call_method)"]
+\tadd [label="add (call_function)"]
+\tclamp [label="clamp (call_method)"]
+\tparam_snk [label="param_snk (stateful_node_sink)"]
+\tx -> add [label=48]
+\tparam -> float_1 [label=48]
+\tparam -> param_snk [label=48]
+\tfloat_1 -> add [label=48]
+\tadd -> clamp [label=48]
+}
+""",
+            )
+
+        with self.subTest("aotautograd"):
+            g, _ = self.importer.import_via_aotautograd(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/weightswithcast.aotautograd.opt4ml.dot")
+
+        with self.subTest("functorch"):
+            g = self.importer.import_via_functorch(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/weightswithcast.functorch.opt4ml.dot")
+
+        with self.subTest("acc_tracer"):
+            g = self.importer.import_via_acc_tracer(
+                simple_module, torch.randn(input_shape), mode="eval"
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/weightswithcast.acc_tracer.opt4ml.dot")
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (weight) [48]"]
+\tto_dtype [label="to_dtype (call_function)"]
+\tadd_1 [label="add_1 (call_function)"]
+\tclamp_1 [label="clamp_1 (call_function)"]
+\tx -> add_1 [label=48]
+\tparam -> to_dtype [label=0]
+\tto_dtype -> add_1 [label=48]
+\tadd_1 -> clamp_1 [label=48]
+}
+""",
+            )
+
+            g.canonicalize()
+            self.assertTrue(g.is_valid())
+            dot = g.dump()
+            print(dot)
+            self.assertEqual(
+                dot,
+                """digraph {
+\tnode [shape=record]
+\tx [label="x (placeholder)"]
+\tparam [label="param (stateful_node)"]
+\tto_dtype [label="to_dtype (call_function)"]
+\tadd_1 [label="add_1 (call_function)"]
+\tclamp_1 [label="clamp_1 (call_function)"]
+\tparam_snk [label="param_snk (stateful_node_sink)"]
+\tx -> add_1 [label=48]
+\tparam -> to_dtype [label=48]
+\tparam -> param_snk [label=48]
+\tto_dtype -> add_1 [label=48]
+\tadd_1 -> clamp_1 [label=48]
+}
+""",
+            )
+
+    def testTrainSimpleGraphWithoutWeightUpdate(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.rand(3, 4))
+                self.linear = torch.nn.Linear(4, 5)
+
+            def forward(self, x):
+                return self.linear(x + self.param).clamp(min=0.0, max=1.0)
+
+        simple_module = SimpleModule()
+        input_shape = (3, 4)
+
+        with self.subTest("functorch"):
+            g = self.importer.import_via_functorch(
+                simple_module,
+                torch.randn(input_shape, requires_grad=True),
+                mode="train",
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/trainsimple.functorch.opt4ml.dot")
+            dot = g.dump()
+            print(dot)
+
+        with self.subTest("aotautograd"):
+            g, _ = self.importer.import_via_aotautograd(
+                simple_module,
+                torch.randn(input_shape, requires_grad=True),
+                mode="train",
+            )
+            self.assertTrue(g.is_valid())
+            # g.dump("/tmp/trainsimple.aotautograd.opt4ml.dot")
+
+            # remove transpose node
+            nodes = g.nodes.copy().values()
+            for node in g.find_nodes(name="t"):
+                self.importer.bypass_and_delete_meta_node(node)
+            # g.dump("/tmp/trainsimple.aotautograd.opt4ml.nometa.dot")
+
+    def testGetItem(self):
+        class PoolingModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                # self.param = torch.nn.Parameter(torch.rand(3, 4))
+                self.pool = torch.nn.MaxPool2d((3, 3), return_indices=True)
+
+            def forward(self, x):
+                res = self.pool(x)[0]
+                return res
+
+        pooling_module = PoolingModule()
+        input_shape = (123, 10, 9, 9)
+
+        g, _ = self.importer.import_via_aotautograd(
+            pooling_module, torch.randn(input_shape, requires_grad=True), mode="train"
+        )
+        self.assertTrue(g.is_valid())
+        # g.dump("/tmp/maxpool.aotautograd.opt4ml.dot")
+        # dot = g.dump()
+        # print(dot)
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+max_pool2d_with_indices (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+max_pool2d_with_indices_backward (call_function)
+
+MultiSourceEdge args_1:0, size:398520, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[max_pool2d_with_indices (call_function), max_pool2d_with_indices_backward (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[max_pool2d_with_indices_backward (call_function)]
+MultiSourceEdge getitem:0_opt, size:44280, mem_space:None, tile_id:None group_id:None sources:[max_pool2d_with_indices (call_function)] sinks:[sum_1 (call_function)]
+MultiSourceEdge getitem_1:0_opt, size:88560, mem_space:None, tile_id:None group_id:None sources:[max_pool2d_with_indices (call_function)] sinks:[max_pool2d_with_indices_backward (call_function)]
+""",
+        )
+
+    def testSplit(self):
+        class SplitModule(torch.nn.Module):
+            def forward(self, x):
+                res = torch.split(x, 3)
+                for slice in res:
+                    assert id(slice.storage()) == id(x.storage())
+                vals = [res[0]]
+                vals.append(torch.relu(res[1]))
+                vals.append(torch.sigmoid(res[2]))
+                return torch.concat(vals)
+
+        split_module = SplitModule()
+        input_shape = (33, 128)
+
+        g, _ = self.importer.import_via_aotautograd(
+            split_module, torch.randn(input_shape, requires_grad=True), mode="train"
+        )
+        self.assertTrue(g.is_valid())
+        # g.dump("/tmp/split.aotautograd.opt4ml.dot")
+        # dot = g.dump()
+        # print(dot)
+        # print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+relu (call_function)
+sigmoid (call_function)
+cat (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+sigmoid_backward (call_function)
+threshold_backward (call_function)
+zeros (call_function)
+zeros_1 (call_function)
+zeros_2 (call_function)
+zeros_3 (call_function)
+zeros_4 (call_function)
+zeros_5 (call_function)
+zeros_6 (call_function)
+zeros_7 (call_function)
+cat_1 (call_function)
+
+MultiSourceEdge args_1:0, size:16896, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[cat (call_function), relu (call_function), sigmoid (call_function)]
+MultiSourceEdge relu:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[relu (call_function)] sinks:[cat (call_function), threshold_backward (call_function)]
+MultiSourceEdge sigmoid:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[sigmoid (call_function)] sinks:[cat (call_function), sigmoid_backward (call_function)]
+MultiSourceEdge cat:0, size:4608, mem_space:None, tile_id:None group_id:None sources:[cat (call_function)] sinks:[sum_1 (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[cat_1 (call_function), threshold_backward (call_function), sigmoid_backward (call_function)]
+MultiSourceEdge sigmoid_backward:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[sigmoid_backward (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge threshold_backward:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[threshold_backward (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_1:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_1 (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_2:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_2 (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_3:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_3 (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_4:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_4 (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_5:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_5 (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_6:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_6 (call_function)] sinks:[cat_1 (call_function)]
+MultiSourceEdge zeros_7:0, size:1536, mem_space:None, tile_id:None group_id:None sources:[zeros_7 (call_function)] sinks:[cat_1 (call_function)]
+""",
+        )
+
+    def testInPlaceOps(self):
+        class InPlaceModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                chan = 15
+                self.conv0 = torch.nn.Conv2d(chan, chan, 3, padding=1)
+                self.bn0 = torch.nn.BatchNorm2d(chan)
+                self.relu0 = torch.nn.ReLU(inplace=True)
+                self.conv1 = torch.nn.Conv2d(chan, chan, 3, padding=1)
+                self.bn1 = torch.nn.BatchNorm2d(chan)
+                self.relu1 = torch.nn.ReLU()
+                self.conv2 = torch.nn.Conv2d(chan, chan, 3, padding=1)
+                self.bn2 = torch.nn.BatchNorm2d(chan)
+                self.relu2 = torch.nn.ReLU()
+                self.conv3 = torch.nn.Conv2d(chan, chan, 3, padding=1)
+                self.conv4 = torch.nn.Conv2d(chan, chan, 3, padding=1)
+
+            def forward(self, x):
+                residual = x
+                res = self.conv0(x)
+                res = self.bn0(res)
+                res = self.relu0(res)
+                res = self.conv1(res)
+                res = self.bn1(res)
+                res += residual
+                residual = res
+                res = self.relu1(res)
+                res = self.conv2(res)
+                res = self.bn2(res)
+                res += residual
+                res = self.relu2(res)
+                res1 = self.conv3(res)
+                res2 = self.conv4(res)
+                return torch.concat([res1, res2])
+
+        in_place_module = InPlaceModule()
+        input_shape = (123, 15, 9, 9)
+
+        optimizer = torch.optim.SGD(in_place_module.parameters(), lr=0.1)
+        g, _ = self.importer.import_via_aotautograd(
+            in_place_module,
+            torch.randn(input_shape, requires_grad=True),
+            mode="train",
+            optimizer=optimizer,
+        )
+        self.assertTrue(g.is_valid(verbose=True))
+        g.dump("/tmp/inplace.aotautograd.opt4ml", "svg")
+        # dot = g.dump()
+        # print(dot)
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+params_1 (weight) [8160]
+params_3 (weight) [240]
+params_5 (weight) [8160]
+params_7 (weight) [240]
+params_9 (weight) [8160]
+params_11 (weight) [240]
+params_13 (weight) [8160]
+params_15 (weight) [8160]
+convolution (call_function)
+native_batch_norm (call_function)
+convolution_1 (call_function)
+native_batch_norm_1 (call_function)
+add__2 (call_function)
+relu (call_function)
+convolution_2 (call_function)
+native_batch_norm_2 (call_function)
+add__4 (call_function)
+relu_1 (call_function)
+convolution_3 (call_function)
+convolution_4 (call_function)
+cat (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+convolution_backward (call_function)
+convolution_backward_1 (call_function)
+add (call_function)
+threshold_backward (call_function)
+native_batch_norm_backward (call_function)
+convolution_backward_2 (call_function)
+threshold_backward_1 (call_function)
+add_1 (call_function)
+native_batch_norm_backward_1 (call_function)
+convolution_backward_3 (call_function)
+threshold_backward_2 (call_function)
+native_batch_norm_backward_2 (call_function)
+convolution_backward_4 (call_function)
+add_2 (call_function)
+add__5 (call_function)
+add__7 (call_function)
+add__9 (call_function)
+add__11 (call_function)
+add__13 (call_function)
+add__15 (call_function)
+add__17 (call_function)
+add__19 (call_function)
+
+MultiSourceEdge args_1:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[convolution (call_function), add__2 (call_function), convolution_backward_4 (call_function), relu (call_function), add__4 (call_function), relu_1 (call_function)]
+MultiSourceEdge params_1:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_1 (weight) [8160]] sinks:[convolution (call_function), convolution_backward_4 (call_function), add__5 (call_function)]
+MultiSourceEdge params_3:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_3 (weight) [240]] sinks:[native_batch_norm (call_function), native_batch_norm_backward_2 (call_function), add__7 (call_function)]
+MultiSourceEdge params_5:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_5 (weight) [8160]] sinks:[convolution_1 (call_function), convolution_backward_3 (call_function), add__9 (call_function)]
+MultiSourceEdge params_7:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_7 (weight) [240]] sinks:[native_batch_norm_1 (call_function), native_batch_norm_backward_1 (call_function), add__11 (call_function)]
+MultiSourceEdge params_9:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_9 (weight) [8160]] sinks:[convolution_2 (call_function), convolution_backward_2 (call_function), add__13 (call_function)]
+MultiSourceEdge params_11:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_11 (weight) [240]] sinks:[native_batch_norm_2 (call_function), native_batch_norm_backward (call_function), add__15 (call_function)]
+MultiSourceEdge params_13:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_13 (weight) [8160]] sinks:[convolution_3 (call_function), convolution_backward_1 (call_function), add__17 (call_function)]
+MultiSourceEdge params_15:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_15 (weight) [8160]] sinks:[convolution_4 (call_function), convolution_backward (call_function), add__19 (call_function)]
+MultiSourceEdge convolution:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution (call_function)] sinks:[native_batch_norm (call_function), native_batch_norm_backward_2 (call_function)]
+MultiSourceEdge convolution_1:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_1 (call_function)] sinks:[native_batch_norm_1 (call_function), native_batch_norm_backward_1 (call_function)]
+MultiSourceEdge add__2:0, size:0, mem_space:None, tile_id:None group_id:None sources:[add__2 (call_function)] sinks:[relu (call_function), add__4 (call_function)]
+MultiSourceEdge relu:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[relu (call_function)] sinks:[convolution_2 (call_function), convolution_backward_2 (call_function), threshold_backward_1 (call_function)]
+MultiSourceEdge convolution_2:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_2 (call_function)] sinks:[native_batch_norm_2 (call_function), native_batch_norm_backward (call_function)]
+MultiSourceEdge add__4:0, size:0, mem_space:None, tile_id:None group_id:None sources:[add__4 (call_function)] sinks:[relu_1 (call_function)]
+MultiSourceEdge relu_1:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[relu_1 (call_function)] sinks:[convolution_3 (call_function), convolution_4 (call_function), convolution_backward (call_function), convolution_backward_1 (call_function), threshold_backward (call_function)]
+MultiSourceEdge convolution_3:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_3 (call_function)] sinks:[cat (call_function)]
+MultiSourceEdge convolution_4:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_4 (call_function)] sinks:[cat (call_function)]
+MultiSourceEdge cat:0, size:1195560, mem_space:None, tile_id:None group_id:None sources:[cat (call_function)] sinks:[sum_1 (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[convolution_backward_1 (call_function), convolution_backward (call_function)]
+MultiSourceEdge add:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[add (call_function)] sinks:[threshold_backward (call_function)]
+MultiSourceEdge threshold_backward:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[threshold_backward (call_function)] sinks:[native_batch_norm_backward (call_function), add_1 (call_function)]
+MultiSourceEdge threshold_backward_1:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[threshold_backward_1 (call_function)] sinks:[add_1 (call_function)]
+MultiSourceEdge add_1:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[add_1 (call_function)] sinks:[native_batch_norm_backward_1 (call_function), add_2 (call_function)]
+MultiSourceEdge threshold_backward_2:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[threshold_backward_2 (call_function)] sinks:[native_batch_norm_backward_2 (call_function)]
+MultiSourceEdge getitem:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm (call_function)] sinks:[convolution_1 (call_function), convolution_backward_3 (call_function), threshold_backward_2 (call_function)]
+MultiSourceEdge getitem_1:0_opt, size:120, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm (call_function)] sinks:[native_batch_norm_backward_2 (call_function)]
+MultiSourceEdge getitem_3:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_1 (call_function)] sinks:[add__2 (call_function)]
+MultiSourceEdge getitem_4:0_opt, size:120, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_1 (call_function)] sinks:[native_batch_norm_backward_1 (call_function)]
+MultiSourceEdge getitem_6:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_2 (call_function)] sinks:[add__4 (call_function)]
+MultiSourceEdge getitem_7:0_opt, size:120, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_2 (call_function)] sinks:[native_batch_norm_backward (call_function)]
+MultiSourceEdge getitem_9:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_backward (call_function)] sinks:[add (call_function)]
+MultiSourceEdge getitem_10:0_opt, size:8160, mem_space:None, tile_id:None group_id:None sources:[convolution_backward (call_function)] sinks:[add__19 (call_function)]
+MultiSourceEdge getitem_12:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_1 (call_function)] sinks:[add (call_function)]
+MultiSourceEdge getitem_13:0_opt, size:8160, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_1 (call_function)] sinks:[add__17 (call_function)]
+MultiSourceEdge getitem_15:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward (call_function)] sinks:[convolution_backward_2 (call_function)]
+MultiSourceEdge getitem_16:0_opt, size:120, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward (call_function)] sinks:[add__15 (call_function)]
+MultiSourceEdge getitem_18:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_2 (call_function)] sinks:[threshold_backward_1 (call_function)]
+MultiSourceEdge getitem_19:0_opt, size:8160, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_2 (call_function)] sinks:[add__13 (call_function)]
+MultiSourceEdge getitem_21:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward_1 (call_function)] sinks:[convolution_backward_3 (call_function)]
+MultiSourceEdge getitem_22:0_opt, size:120, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward_1 (call_function)] sinks:[add__11 (call_function)]
+MultiSourceEdge getitem_24:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_3 (call_function)] sinks:[threshold_backward_2 (call_function)]
+MultiSourceEdge getitem_25:0_opt, size:8160, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_3 (call_function)] sinks:[add__9 (call_function)]
+MultiSourceEdge getitem_27:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward_2 (call_function)] sinks:[convolution_backward_4 (call_function)]
+MultiSourceEdge getitem_28:0_opt, size:120, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward_2 (call_function)] sinks:[add__7 (call_function)]
+MultiSourceEdge getitem_30:0_opt, size:597780, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_4 (call_function)] sinks:[add_2 (call_function)]
+MultiSourceEdge getitem_31:0_opt, size:8160, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_4 (call_function)] sinks:[add__5 (call_function)]
+""",
+        )
+
+    def testDropout(self):
+        class DropoutModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dropout = torch.nn.Dropout(p=0.3)
+
+            def forward(self, x):
+                res = self.dropout(x)
+                return res
+
+        dropout_module = DropoutModule()
+        input_shape = (32, 100)
+
+        g, _ = self.importer.import_via_aotautograd(
+            dropout_module,
+            torch.randn(input_shape, requires_grad=True),
+            mode="train",
+            optimizer=True,
+        )
+        self.assertTrue(g.check_consistency())
+        g.dump("/tmp/dropout.aotautograd.opt4ml", "svg")
+        # dot = g.dump()
+        # print(dot)
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+empty_like (call_function)
+mul (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+mul_1 (call_function)
+
+MultiSourceEdge args_1:0, size:12800, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[empty_like (call_function), mul (call_function)]
+MultiSourceEdge empty_like:0, size:12800, mem_space:None, tile_id:None group_id:None sources:[empty_like (call_function)] sinks:[mul (call_function), mul_1 (call_function)]
+MultiSourceEdge mul:0, size:12800, mem_space:None, tile_id:None group_id:None sources:[mul (call_function)] sinks:[sum_1 (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[mul_1 (call_function)]
+""",
+        )
+
+    def testStochasticDepth(self):
+        class SDModule(torch.nn.Module):
+            def forward(self, x):
+                survival_rate = 0.8
+                size = [x.shape[0]] + [1] * (x.ndim - 1)
+                noise = torch.empty(size, dtype=x.dtype)
+                noise = noise.bernoulli_(survival_rate)
+                noise.div_(survival_rate)
+                rslt = x * noise
+                rslt += x
+                return rslt
+
+        sd_module = SDModule()
+        input_shape = (32, 100)
+
+        g, _ = self.importer.import_via_aotautograd(
+            sd_module,
+            torch.randn(input_shape, requires_grad=True),
+            mode="train",
+            optimizer=True,
+        )
+        self.assertTrue(g.check_consistency())
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+empty (call_function)
+mul (call_function)
+add_ (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+mul_1 (call_function)
+add (call_function)
+
+MultiSourceEdge args_1:0, size:12800, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[mul (call_function), add_ (call_function), sum_1 (call_function)]
+MultiSourceEdge empty:0, size:128, mem_space:None, tile_id:None group_id:None sources:[empty (call_function)] sinks:[mul (call_function), mul_1 (call_function)]
+MultiSourceEdge mul:0, size:12800, mem_space:None, tile_id:None group_id:None sources:[mul (call_function)] sinks:[add_ (call_function)]
+MultiSourceEdge add_:0, size:0, mem_space:None, tile_id:None group_id:None sources:[add_ (call_function)] sinks:[sum_1 (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[mul_1 (call_function), add (call_function)]
+MultiSourceEdge mul_1:0, size:12800, mem_space:None, tile_id:None group_id:None sources:[mul_1 (call_function)] sinks:[add (call_function)]
+""",
+        )
+
+    def testRemoveMetaNode(self):
+        g = dataflow_graph.Graph()
+
+        A = g.add_node(name="a")
+        B = g.add_node(name="b")
+        C = g.add_node(name="c")
+        D = g.add_node(name="d")
+        E = g.add_node(name="e")
+        F = g.add_node(name="f")
+        G = g.add_node(name="g")
+        H = g.add_node(name="h", size=322)
+        I = g.add_node(name="i")
+        J = g.add_node(name="j")
+
+        """
+        Test deleting node B, whose parent is connected to another node
+        A - B - D
+         \\   //
+            C
+        """
+        g.add_edge([A], [B], 123, name="e1")
+        g.add_edge([A], [C], 456, name="e2")
+        g.add_edge([B], [D], 123, name="e3")
+        g.add_edge([C], [D], 789, name="e4")
+        """
+        Test deleting node E, that is connected to > 1 node
+                H
+             // |
+        D - E - G
+          \\  //
+            F
+        """
+        g.add_edge([D], [E, F], 1034, name="e5")
+        g.add_edge([E], [G, H], 1034, name="e6")
+        g.add_edge([F], [G], 1089, name="e7")
+        g.add_edge([G], [H], 1089, name="e8")
+        """
+        Test deleting node I, that has an incoming edge of size 0, but a neighbor node with size > 0
+        H - I - J
+        """
+        g.add_edge([H], [I], 0, name="e9")
+        g.add_edge([I], [J], 322, name="e10")
+
+        g.canonicalize()
+
+        g.sort()
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\ta [label="<f0> a_0|<f1> a_1"]
+\tb [label=b]
+\tc [label=c]
+\td [label=d]
+\te [label=e]
+\tf [label=f]
+\tg [label=g]
+\th [label="h (stateful_node)"]
+\th_snk [label="h_snk (stateful_node_sink)"]
+\ti [label=i]
+\tj [label=j]
+\ta:f0 -> b [label=123]
+\ta:f1 -> c [label=456]
+\tb -> d [label=123]
+\tc -> d [label=789]
+\td -> e [label=1034]
+\td -> f [label=1034]
+\te -> g [label=1034]
+\te -> h [label=1034]
+\tf -> g [label=1089]
+\tg -> h [label=1089]
+\th -> i [label=322]
+\th -> h_snk [label=322]
+\ti -> j [label=322]
+}
+""",
+        )
+
+        self.importer.bypass_and_delete_meta_node(g, B)
+
+        g.sort()
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\ta [label="<f0> a_0|<f1> a_1"]
+\tc [label=c]
+\td [label=d]
+\te [label=e]
+\tf [label=f]
+\tg [label=g]
+\th [label="h (stateful_node)"]
+\th_snk [label="h_snk (stateful_node_sink)"]
+\ti [label=i]
+\tj [label=j]
+\ta:f0 -> d [label=123]
+\ta:f1 -> c [label=456]
+\tc -> d [label=789]
+\td -> e [label=1034]
+\td -> f [label=1034]
+\te -> g [label=1034]
+\te -> h [label=1034]
+\tf -> g [label=1089]
+\tg -> h [label=1089]
+\th -> i [label=322]
+\th -> h_snk [label=322]
+\ti -> j [label=322]
+}
+""",
+        )
+
+        self.importer.bypass_and_delete_meta_node(g, E)
+
+        g.sort()
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\ta [label="<f0> a_0|<f1> a_1"]
+\tc [label=c]
+\td [label=d]
+\tf [label=f]
+\tg [label=g]
+\th [label="h (stateful_node)"]
+\th_snk [label="h_snk (stateful_node_sink)"]
+\ti [label=i]
+\tj [label=j]
+\ta:f0 -> d [label=123]
+\ta:f1 -> c [label=456]
+\tc -> d [label=789]
+\td -> f [label=1034]
+\td -> g [label=1034]
+\td -> h [label=1034]
+\tf -> g [label=1089]
+\tg -> h [label=1089]
+\th -> i [label=322]
+\th -> h_snk [label=322]
+\ti -> j [label=322]
+}
+""",
+        )
+
+        self.importer.bypass_and_delete_meta_node(g, I)
+
+        g.sort()
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            dot,
+            """digraph {
+\tnode [shape=record]
+\ta [label="<f0> a_0|<f1> a_1"]
+\tc [label=c]
+\td [label=d]
+\tf [label=f]
+\tg [label=g]
+\th [label="h (stateful_node)"]
+\th_snk [label="h_snk (stateful_node_sink)"]
+\tj [label=j]
+\ta:f0 -> d [label=123]
+\ta:f1 -> c [label=456]
+\tc -> d [label=789]
+\td -> f [label=1034]
+\td -> g [label=1034]
+\td -> h [label=1034]
+\tf -> g [label=1089]
+\tg -> h [label=1089]
+\th -> h_snk [label=322]
+\th -> j [label=322]
+}
+""",
+        )
+
+    def testMLP(self):
+        class MLPModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(125, 125)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                res = self.relu(self.linear(x))
+                return res
+
+        bn_module = MLPModule()
+        input_shape = (32, 125)
+
+        g, _ = self.importer.import_via_aotautograd(
+            bn_module, torch.randn(input_shape), mode="train", optimizer=True
+        )
+        self.assertTrue(g.is_valid())
+        # g.dump("/tmp/mlp.aotautograd.opt4ml", "svg")
+        # dot = g.dump()
+        # print(dot)
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+params_2 (weight) [63000]
+addmm (call_function)
+relu (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+threshold_backward (call_function)
+mm (call_function)
+sum_2 (call_function)
+sub (call_function)
+sub_1 (call_function)
+
+MultiSourceEdge args_1:0, size:16000, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[addmm (call_function), mm (call_function)]
+MultiSourceEdge params_2:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_2 (weight) [63000]] sinks:[addmm (call_function), sub_1 (call_function), sub (call_function)]
+MultiSourceEdge addmm:0, size:16000, mem_space:None, tile_id:None group_id:None sources:[addmm (call_function)] sinks:[relu (call_function)]
+MultiSourceEdge relu:0, size:16000, mem_space:None, tile_id:None group_id:None sources:[relu (call_function)] sinks:[sum_1 (call_function), threshold_backward (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[threshold_backward (call_function)]
+MultiSourceEdge threshold_backward:0, size:16000, mem_space:None, tile_id:None group_id:None sources:[threshold_backward (call_function)] sinks:[sum_2 (call_function), mm (call_function)]
+MultiSourceEdge mm:0, size:62500, mem_space:None, tile_id:None group_id:None sources:[mm (call_function)] sinks:[sub (call_function)]
+MultiSourceEdge sum_2:0, size:500, mem_space:None, tile_id:None group_id:None sources:[sum_2 (call_function)] sinks:[sub_1 (call_function)]
+""",
+        )
+
+    def testBatchNorm(self):
+        class BNConvModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                # self.param = torch.nn.Parameter(torch.rand(3, 4))
+                in_chan = 15
+                out_chan = 10
+                self.conv = torch.nn.Conv2d(in_chan, out_chan, 3)
+                self.bn = torch.nn.BatchNorm2d(out_chan)
+                self.conv2 = torch.nn.Conv2d(out_chan, 5, 3)
+
+            def forward(self, x):
+                res = self.conv2(self.bn(self.conv(x)))
+                return res
+
+        bn_module = BNConvModule()
+        input_shape = (123, 15, 9, 9)
+
+        g, _ = self.importer.import_via_aotautograd(
+            bn_module, torch.randn(input_shape), mode="train", optimizer=True
+        )
+        self.assertTrue(g.is_valid())
+        # g.dump("/tmp/batchnorm.aotautograd.opt4ml", "svg")
+        # dot = g.dump()
+        # print(dot)
+        print(str(g))
+        self.assertEqual(
+            str(g),
+            """args_1 (placeholder)
+params_1 (weight) [5440]
+params_3 (weight) [160]
+params_5 (weight) [1820]
+convolution (call_function)
+native_batch_norm (call_function)
+convolution_1 (call_function)
+sum_1 (call_function)
+ones_like (call_function)
+convolution_backward (call_function)
+native_batch_norm_backward (call_function)
+convolution_backward_1 (call_function)
+sub (call_function)
+sub_2 (call_function)
+sub_4 (call_function)
+
+MultiSourceEdge args_1:0, size:597780, mem_space:None, tile_id:None group_id:None sources:[args_1 (placeholder)] sinks:[convolution (call_function), convolution_backward_1 (call_function)]
+MultiSourceEdge params_1:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_1 (weight) [5440]] sinks:[convolution (call_function), convolution_backward_1 (call_function), sub (call_function)]
+MultiSourceEdge params_3:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_3 (weight) [160]] sinks:[native_batch_norm (call_function), native_batch_norm_backward (call_function), sub_2 (call_function)]
+MultiSourceEdge params_5:0, size:0, mem_space:None, tile_id:None group_id:None sources:[params_5 (weight) [1820]] sinks:[convolution_1 (call_function), convolution_backward (call_function), sub_4 (call_function)]
+MultiSourceEdge convolution:0, size:241080, mem_space:None, tile_id:None group_id:None sources:[convolution (call_function)] sinks:[native_batch_norm (call_function), native_batch_norm_backward (call_function)]
+MultiSourceEdge convolution_1:0, size:61500, mem_space:None, tile_id:None group_id:None sources:[convolution_1 (call_function)] sinks:[sum_1 (call_function)]
+MultiSourceEdge sum_1:0, size:4, mem_space:None, tile_id:None group_id:None sources:[sum_1 (call_function)] sinks:[ones_like (call_function)]
+MultiSourceEdge ones_like:0, size:4, mem_space:None, tile_id:None group_id:None sources:[ones_like (call_function)] sinks:[convolution_backward (call_function)]
+MultiSourceEdge getitem:0_opt, size:241080, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm (call_function)] sinks:[convolution_1 (call_function), convolution_backward (call_function)]
+MultiSourceEdge getitem_1:0_opt, size:80, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm (call_function)] sinks:[native_batch_norm_backward (call_function)]
+MultiSourceEdge getitem_3:0_opt, size:241080, mem_space:None, tile_id:None group_id:None sources:[convolution_backward (call_function)] sinks:[native_batch_norm_backward (call_function)]
+MultiSourceEdge getitem_4:0_opt, size:1820, mem_space:None, tile_id:None group_id:None sources:[convolution_backward (call_function)] sinks:[sub_4 (call_function)]
+MultiSourceEdge getitem_6:0_opt, size:241080, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward (call_function)] sinks:[convolution_backward_1 (call_function)]
+MultiSourceEdge getitem_7:0_opt, size:80, mem_space:None, tile_id:None group_id:None sources:[native_batch_norm_backward (call_function)] sinks:[sub_2 (call_function)]
+MultiSourceEdge getitem_10:0_opt, size:5440, mem_space:None, tile_id:None group_id:None sources:[convolution_backward_1 (call_function)] sinks:[sub (call_function)]
+""",
+        )
+
+    def testMultiSinkMultiSource(self):
+        class MultiSinkModule(torch.nn.Module):
+            def forward(self, x):
+                y1 = x.relu()
+                y2 = x.sin()
+                z = y1 + y2
+                z1, z2 = z.split(2)
+                return z1 + z2
+
+        simple_module = MultiSinkModule()
+        input_shape = (3, 4)
+
+        g = self.importer.import_from_torch(simple_module, torch.randn(input_shape))
+        self.assertTrue(g.is_valid())
+
+        # log dot files of dataflow and fx graphs
+        # g.dump("/tmp/multiSinkMultiSource.via_fx.df.dot")
+        torch.fx.passes.graph_drawer.FxGraphDrawer(
+            self.importer.fx_trace, "multiSinkMultiSource"
+        ).get_dot_graph().write("/tmp/multiSinkMultiSource.via_fx.fx.dot")
+
+        dot = g.dump()
+        print(dot)
+
+    def testImportWithTimeProfile(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 3, kernel_size=3)
+                self.relu = torch.nn.ReLU(inplace=True)
+                self.conv2 = torch.nn.Conv2d(3, 3, kernel_size=3)
+                self.conv3 = torch.nn.Conv2d(3, 3, kernel_size=3)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = self.relu(x)
+                x = self.conv2(x)
+                x = x.relu()
+                x = self.conv3(x)
+                return x.sigmoid()
+
+        simple_module = SimpleModule()
+        input_shape = (1, 3, 10, 10)
+
+        if True:
+            print("Import using default method")
+            g = self.importer.import_from_torch(
+                simple_module, torch.randn(input_shape), profile=["time"]
+            )
+            self.assertTrue(g.is_valid())
+
+            # log dot files of dataflow and fx graphs
+            # g.dump("/tmp/importWithTimeProfile.default.df.dot")
+
+            dot = g.dump()
+            print(dot)
+
+            # verify that each node has been profiled
+            for node in g.nodes.values():
+                assert (
+                    node.time and node.time > 0
+                ), f"Profiled execution time of node {node.name} is {node.time} but should be greater than zero."
+
+        if True:
+            print("Import using aotautograd method")
+            g, _ = self.importer.import_via_aotautograd(
+                simple_module,
+                torch.randn(input_shape),
+                mode="train",
+                optimizer=torch.optim.SGD(simple_module.parameters(), lr=0.1),
+                profile=["time"],
+            )
+            self.assertTrue(g.is_valid())
+
+            # log dot files of dataflow and fx graphs
+            # g.dump("/tmp/importWithTimeProfile.aotautograd.df.dot")
+
+            dot = g.dump()
+            print(dot)
+
+            # when using torch.optim.SGD, inplace ops cannot be profiled
+            for node in g.nodes.values():
+                assert (
+                    (node.time and node.time > 0)
+                    or node.name == "add_"
+                    or node.name.startswith("add__")
+                ), f"Profiled execution time of node {node.name} is {node.time} but should be greater than zero as it is not an `add_` in place node."
+
+        if True:
+            print("Import using acctracer method")
+            g = self.importer.import_via_acc_tracer(
+                simple_module, torch.randn(input_shape), profile=["time"]
+            )
+            self.assertTrue(g.is_valid())
+
+            # log dot files of dataflow and fx graphs
+            # g.dump("/tmp/importWithTimeProfile.acc_tracer.df.dot")
+
+            dot = g.dump()
+            print(dot)
+
+            # verify that each node has been profiled
+            for node in g.nodes.values():
+                assert (
+                    node.time and node.time > 0
+                ), f"Profiled execution time of node {node.name} is {node.time} but should be greater than zero."
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(),
+        "Memory profiling currently only works with CUDA",
+    )
+    def testImportWithMemoryProfile(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 3, kernel_size=3)
+                self.relu = torch.nn.ReLU(inplace=True)
+                self.conv2 = torch.nn.Conv2d(3, 3, kernel_size=3)
+                self.conv3 = torch.nn.Conv2d(3, 3, kernel_size=3)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = self.relu(x)
+                x = self.conv2(x)
+                x = x.relu()
+                x = self.conv3(x)
+                return x.sigmoid()
+
+        simple_module = SimpleModule()
+
+        input_shape = (1, 3, 10, 10)
+        input = torch.randn(input_shape)
+
+        # move to GPU to enable CUDA memory profile
+        simple_module.cuda()
+        input = input.cuda()
+
+        if True:
+            g = self.importer.import_from_torch(
+                simple_module, input, profile=["time", "memory"]
+            )
+            self.assertTrue(g.is_valid())
+
+            # log dot files of dataflow and fx graphs
+            # g.dump("/tmp/importWithMemoryProfile.default.df.dot")
+
+            dot = g.dump()
+            print(dot)
+
+            # TODO: after loading memory stats into each node, verify some memory stats rather than time
+            # verify that each node has been profiled
+            for node in g.nodes.values():
+                assert (
+                    node.time and node.time > 0
+                ), f"Profiled execution time of node {node.name} is {node.time} but should be greater than zero."
+
+        if True:
+            g, _ = self.importer.import_via_aotautograd(
+                simple_module,
+                input,
+                mode="train",
+                optimizer=torch.optim.SGD(simple_module.parameters(), lr=0.1),
+                profile=["time", "memory"],
+            )
+            self.assertTrue(g.is_valid())
+
+            # log dot files of dataflow and fx graphs
+            # g.dump("/tmp/importWithMemoryProfile.aotautograd.df.dot")
+
+            dot = g.dump()
+            print(dot)
+
+            # TODO: after loading memory stats into each node, verify some memory stats rather than time
+            # when using torch.optim.SGD, inplace ops cannot be profiled
+            for node in g.nodes.values():
+                assert (
+                    (node.time and node.time > 0)
+                    or node.name == "add_"
+                    or node.name.startswith("add__")
+                ), f"Profiled execution time of node {node.name} is {node.time} but should be greater than zero as it is not an `add_` in place node."
+
+        if True:
+            g = self.importer.import_via_acc_tracer(
+                simple_module, input, profile=["time", "memory"]
+            )
+            self.assertTrue(g.is_valid())
+
+            # log dot files of dataflow and fx graphs
+            # g.dump("/tmp/importWithMemoryProfile.acc_tracer.df.dot")
+
+            dot = g.dump()
+            print(dot)
+
+            # TODO: after loading memory stats into each node, verify some memory stats rather than time
+            # verify that each node has been profiled
+            for node in g.nodes.values():
+                assert (
+                    node.time and node.time > 0
+                ), f"Profiled execution time of node {node.name} is {node.time} but should be greater than zero."
+
+        if True:
+            # FIXME: profiling currently fails with functorch
+            pass

--- a/tests/torch_graph_importer_test_transformers.py
+++ b/tests/torch_graph_importer_test_transformers.py
@@ -1,0 +1,103 @@
+import unittest
+
+import torch
+import torch.fx
+
+from olla.torch import torch_graph_importer
+
+
+class TorchGraphImporterTestVision(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+        self.maxDiff = None
+
+    def run_tests(
+        self,
+        model,
+        *inputs,
+        mode="eval",
+        methods=None,
+        optimizer=None,
+        test_name="test",
+    ):
+        if methods is None:
+            methods = ["aotautograd"]
+
+        for method in methods:
+            with self.subTest():
+                g = self.importer.import_from_torch(
+                    model,
+                    *inputs,
+                    mode=mode,
+                    method=method,
+                    optimizer=optimizer,
+                )
+                self.assertTrue(g.check_consistency())
+                # g.dump(f"/tmp/{test_name}.{method}.dot")
+
+    def testTransformerDecoderLayerInference(self):
+        model = torch.nn.TransformerDecoderLayer(d_model=512, nhead=8)
+        memory = torch.rand(10, 32, 512)
+        tgt = torch.rand(20, 32, 512)
+
+        model.eval()
+        self.run_tests(
+            model,
+            memory,
+            tgt,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                # "acc_tracer", # FIXME: Error message: P523544272
+            ],
+            test_name="transformer.decoder.inference",
+        )
+
+    def testTransformerEncoderLayerTrainDefaultOptimizer(self):
+        batch_size, seq_len, embedding_dim = 32, 256, 1024
+        model = torch.nn.TransformerEncoderLayer(
+            d_model=embedding_dim, nhead=16, dim_feedforward=4096
+        )
+        input_shapes = [(batch_size, seq_len, embedding_dim)]
+        inputs = [torch.randn(s, requires_grad=True) for s in input_shapes]
+
+        model.train()
+        self.run_tests(
+            model,
+            *inputs,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: F0821 15:06:40.033880 1327465 layer_norm_kernel.cpp:120] Check failed: dY.numel() == M * N (262144 vs. 8388608)
+            ],
+            optimizer=True,
+            test_name="transformer.encoder.train",
+        )
+
+    def testTransformerEncoderLayerTrainSGDOptimizer(self):
+        batch_size, seq_len, embedding_dim = 32, 256, 1024
+        model = torch.nn.TransformerEncoderLayer(
+            d_model=embedding_dim, nhead=16, dim_feedforward=4096
+        )
+        input_shapes = [(batch_size, seq_len, embedding_dim)]
+        inputs = [torch.randn(s, requires_grad=True) for s in input_shapes]
+
+        # Fix the case where we use momentum and weight_decay: T126360101
+        optimizer = torch.optim.SGD(
+            model.parameters(), lr=0.1  # , momentum=0.9, weight_decay=1e-4
+        )
+
+        model.train()
+        self.run_tests(
+            model,
+            *inputs,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME
+            ],
+            optimizer=optimizer,
+            test_name="transformer.encoder.train.sgd",
+        )

--- a/tests/torch_graph_importer_test_vision.py
+++ b/tests/torch_graph_importer_test_vision.py
@@ -1,0 +1,466 @@
+import unittest
+
+import torch
+import torch.fx
+import torchvision
+
+from olla.torch import torch_graph_importer
+
+
+class TorchGraphImporterTestVision(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+        self.maxDiff = None
+
+    def run_tests(
+        self,
+        model,
+        *inputs,
+        mode="eval",
+        methods=None,
+        optimizer=None,
+        test_name="test",
+    ):
+        if methods is None:
+            methods = ["aotautograd"]
+
+        for method in methods:
+            print(f"Import using {method}")
+            g = self.importer.import_from_torch(
+                model,
+                *inputs,
+                mode=mode,
+                method=method,
+                optimizer=optimizer,
+            )
+            self.assertTrue(g.check_consistency())
+            # g.dump(f"/tmp/{test_name}.{method}.dot")
+
+    def testAlexNetInference(self):
+        model = torchvision.models.alexnet()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                "fx",
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="alexnet.inference",
+        )
+
+    def testAlexNetTrain(self):
+        model = torchvision.models.alexnet()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523547974
+            ],
+            test_name="alexnet.train",
+        )
+
+    def testSqueezeNetInference(self):
+        model = torchvision.models.squeezenet1_0()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                "fx",
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="squeezenet1_0.inference",
+        )
+
+    def testSqueezeNetTrain(self):
+        model = torchvision.models.squeezenet1_0()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+            ],
+            test_name="squeezenet1_0.train",
+        )
+
+    def testDenseNetInference(self):
+        model = torchvision.models.densenet161()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="densenet161.inference",
+        )
+
+    def testDenseNetTrain(self):
+        model = torchvision.models.densenet161()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", #FIXME: Error message: P523547974
+            ],
+            test_name="densenet161.train",
+        )
+
+    def testInceptionInference(self):
+        model = torchvision.models.inception_v3()
+        input = torch.randn((1, 3, 299, 299))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="inception_v3.inference",
+        )
+
+    def testInceptionTrain(self):
+        # inception model returns a namedtuple (logits, aux_logits)
+        # so will wrap the model to return their concatenation
+        class InceptionWrapper(torch.nn.Module):
+            def __init__(self):
+                super(InceptionWrapper, self).__init__()
+                self.model = torchvision.models.inception_v3()
+
+            def forward(self, x):
+                (logits, aux_logits) = self.model(x)
+                return torch.cat([logits, aux_logits])
+
+        model = InceptionWrapper()
+
+        input = torch.randn((32, 3, 299, 299), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", #FIXME: Error message: P523547974
+            ],
+            test_name="inception_v3.train",
+        )
+
+    def testGoogleNetInference(self):
+        model = torchvision.models.googlenet()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="googlenet.inference",
+        )
+
+    def testGoogleNetTrain(self):
+        class GoogleNetWrapper(torch.nn.Module):
+            def __init__(self):
+                super(GoogleNetWrapper, self).__init__()
+                self.model = torchvision.models.googlenet()
+
+            def forward(self, x):
+                rslt = self.model(x)
+                return torch.concat((rslt[0], rslt[1], rslt[2]), dim=-1)
+
+        model = GoogleNetWrapper()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+            ],
+            test_name="googlenet.train",
+        )
+
+    def testShuffleNetInference(self):
+        model = torchvision.models.shufflenet_v2_x1_0()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                # "acc_tracer", # FIXME: P524956696
+            ],
+            test_name="shufflenet_v2_x1_0.inference",
+        )
+
+    def testShuffleNetTrain(self):
+        model = torchvision.models.shufflenet_v2_x1_0()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523546037
+            ],
+            test_name="shufflenet_v2_x1_0.train",
+        )
+
+    def testMobileNetv2Inference(self):
+        model = torchvision.models.mobilenet_v2()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="mobilenet_v2.inference",
+        )
+
+    def testMobileNetv2Train(self):
+        model = torchvision.models.mobilenet_v2()
+        input = torch.randn((32, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523547567
+            ],
+            test_name="mobilenet_v2.train",
+        )
+
+    def testResNet18Inference(self):
+        model = torchvision.models.resnet18()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="resnet18.inference",
+        )
+
+    def testResNet18Train(self):
+        model = torchvision.models.resnet18()
+        input = torch.randn((32, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: error message: P523546919
+            ],
+            test_name="resnet18.train",
+        )
+
+    def testResNext50_32x4dInference(self):
+        model = torchvision.models.resnext50_32x4d()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="resnext50_32x4d.inference",
+        )
+
+    def testResNext50_32x4dTrain(self):
+        model = torchvision.models.resnext50_32x4d()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523546356
+            ],
+            test_name="resnext50_32x4d.train",
+        )
+
+    def testWideResNet50_2Inference(self):
+        model = torchvision.models.wide_resnet50_2()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="wide_resnet50_2.inference",
+        )
+
+    def testWideResNet50_2Train(self):
+        model = torchvision.models.wide_resnet50_2()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523543780
+            ],
+            test_name="wide_resnet50_2.train",
+        )
+
+    def testMNasNetInference(self):
+        model = torchvision.models.mnasnet1_0()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                # "fx", # FIXME
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="mnasnet1_0.inference",
+        )
+
+    def testMNasNetTrain(self):
+        model = torchvision.models.mnasnet1_0()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523547974
+            ],
+            test_name="mnasnet1_0.train",
+        )
+
+    def testVGG11Inference(self):
+        model = torchvision.models.vgg11()
+        input = torch.randn((1, 3, 224, 224))
+
+        model.eval()
+        self.run_tests(
+            model,
+            input,
+            mode="eval",
+            methods=[
+                "fx",
+                "aotautograd",
+                "functorch",
+                "acc_tracer",
+            ],
+            test_name="vgg11.inference",
+        )
+
+    def testVGG11TrainDefaultOptimizer(self):
+        model = torchvision.models.vgg11()
+        input = torch.randn((1, 3, 224, 224), requires_grad=True)
+        optimizer = True
+
+        model.train()
+        self.run_tests(
+            model,
+            input,
+            mode="train",
+            methods=[
+                "aotautograd",
+                # "functorch", # FIXME: Error message: P523543991
+            ],
+            optimizer=optimizer,
+            test_name="vgg11.train",
+        )

--- a/tests/torch_scheduler_test.py
+++ b/tests/torch_scheduler_test.py
@@ -1,0 +1,57 @@
+import os
+import unittest
+
+import torch
+import torch.fx
+from olla import scheduler
+from olla.torch import torch_graph_importer
+
+del os.environ["LD_LIBRARY_PATH"]
+
+
+class TorchGraphScheduler(unittest.TestCase):
+    def setUp(self):
+        self.importer = torch_graph_importer.TorchGraphImporter()
+        self.maxDiff = None
+
+    def testSimpleGraph(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.rand(3, 4))
+                self.linear = torch.nn.Linear(4, 5)
+
+            def forward(self, x):
+                return self.linear(x + self.param).clamp(min=0.0, max=1.0)
+
+        simple_module = SimpleModule()
+        input_shape = (3, 4)
+
+        g = self.importer.import_from_torch(simple_module, torch.randn(input_shape))
+        g.canonicalize()
+        # g.constrain_weights()   #we do not need/support this anymore
+        s = scheduler.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            max_spills=0,
+            account_for_fragmentation=True,
+        )
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+
+        # g.dump("/tmp/new_simple.fx.opt4ml.dot")
+        dot = g.dump()
+        print(dot)
+        self.assertEqual(
+            s,
+            [
+                "x:0: (['1@116'], [2], []) ",
+                "param:0: (['1@68'], [2], []) ",
+                "add:0: (['2@20'], [3, 4, 5, 6, 7, 8, 9], []) ",
+                "linear_weight:0: (['8@68'], [9], []) ",
+                "linear_bias:0: (['8@0'], [9], []) ",
+                "linear:0: (['9@148'], [], []) ",
+            ],
+        )

--- a/tests/training_graph_optimizer_large_test.py
+++ b/tests/training_graph_optimizer_large_test.py
@@ -1,0 +1,50 @@
+import unittest
+
+from olla import training_graph_optimizer, utils
+from olla.native_graphs import graph_with_gradients
+
+
+class SchedulerTest(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def testGraphWithGradients(self):
+        g = graph_with_gradients.graph
+
+        self.assertTrue(g.check_consistency())
+        self.assertTrue(g.is_valid())
+
+        dot = g.dump()
+        print(dot)
+        # g.dump("/tmp/graph_with_gradient_gv", format="png")
+
+        s = training_graph_optimizer.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1209,
+            allow_swaps=True,
+            max_spills=None,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 1209)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 1824)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "ACTIVATION1: ([3], [4, 5, 6], []) ",
+                "WEIGHT_REF1: ([3], [4, 5, 8], [7]) ",
+                "ACTIVATION2: ([4], [5, 6, 7, 8, 9], []) ",
+                "WEIGHT_REF2: ([1], [2, 3, 4, 5, 11, 12], [10]) ",
+                "OUTPUT_EDGE: ([5], [], []) ",
+                "PROPAGATE_G1: ([1], [2], [9]) ",
+                "PROPAGATE_G2: ([2], [3, 4, 5, 6], []) ",
+                "UPDATE_W1: ([6], [7], []) ",
+                "UPDATE_W2: ([9], [10, 11, 12], []) ",
+            ],
+        )

--- a/tests/training_graph_optimizer_test.py
+++ b/tests/training_graph_optimizer_test.py
@@ -1,0 +1,498 @@
+import unittest
+from collections import defaultdict
+
+from olla import training_graph_optimizer, utils
+from olla.native_graphs import (
+    diamond_graph,
+    graph_with_bmmadd,
+    graph_with_constants,
+    graph_with_two_weights,
+    graph_with_weights,
+)
+
+
+class SchedulerTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testTimestepFactor(self):
+        g = diamond_graph.graph
+        s = training_graph_optimizer.Scheduler(g, timestep_factor=0.1)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            max_spills=None,
+        )
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+        self.assertTrue(utils.validate_node_ordering(g, schedule))
+
+    def testGraphWithConstants(self):
+        g = graph_with_constants.graph
+
+        s = training_graph_optimizer.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            max_spills=None,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 93)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+        self.assertTrue(utils.validate_node_ordering(g, schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "ACTIVATION_EDGE: ([1], [2], []) ",
+                "CONSTANT_EDGE: ([1], [2, 3], []) ",
+                "OUTPUT_EDGE: ([2], [], []) ",
+            ],
+        )
+
+    def testGraphWithWeights(self):
+        g = graph_with_weights.graph
+
+        s = training_graph_optimizer.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            max_spills=None,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 183)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+        self.assertTrue(utils.validate_node_ordering(g, schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "ACTIVATION_EDGE: ([1], [2], []) ",
+                "WEIGHT_EDGE: ([1], [2, 3], []) ",
+                "OUTPUT_EDGE: ([2], [], []) ",
+            ],
+        )
+
+    def testNonTrivialGraph(self):
+        g = graph_with_two_weights.graph
+
+        s = training_graph_optimizer.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=1024,
+            allow_swaps=True,
+            max_spills=None,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 524)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 0)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+        self.assertTrue(utils.validate_node_ordering(g, schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "ACTIVATION1: ([1], [2], []) ",
+                "WEIGHT_REF1: ([1], [2, 3, 4], []) ",
+                "ACTIVATION2: ([2], [3], []) ",
+                "WEIGHT_REF2: ([1], [2, 3, 4], []) ",
+                "OUTPUT_EDGE: ([3], [], []) ",
+            ],
+        )
+
+    def testMemoryPressure(self):
+        g = graph_with_two_weights.graph
+
+        s = training_graph_optimizer.Scheduler(g)
+        summary, schedule, mem_loc = s.ComputeOptimalSchedule(
+            mem_limit=500,
+            allow_swaps=True,
+            max_spills=None,
+        )
+
+        self.assertEqual(summary["peak_mem_usage"], 484)
+        self.assertLessEqual(summary["peak_mem_usage"], summary["required_memory"])
+        self.assertEqual(summary["total_data_swapped"], 246)
+
+        self.assertTrue(utils.validate_address_allocation(mem_loc))
+        self.assertTrue(utils.validate_timeline(schedule))
+        self.assertTrue(utils.validate_node_ordering(g, schedule))
+
+        s = [n.name + ": " + str(s) + " " for n, s in schedule.items()]
+        print(str(s))
+        self.assertEqual(
+            s,
+            [
+                "ACTIVATION1: ([1], [2], []) ",
+                "WEIGHT_REF1: ([1], [2], []) ",
+                "ACTIVATION2: ([2], [3], []) ",
+                "WEIGHT_REF2: ([1], [2, 3, 4], []) ",
+                "OUTPUT_EDGE: ([3], [], []) ",
+            ],
+        )
+
+    def testTimestepIterators(self):
+        g = graph_with_two_weights.graph
+
+        s = training_graph_optimizer.Scheduler(g, timestep_factor=1)
+        asap = s.ComputeASAPSchedule({})
+        alap = s.ComputeALAPSchedule({}, max_timesteps=s.num_nodes)
+        makespan = s.ComputeMakespans(asap, alap)
+
+        self.assertEqual(
+            str(makespan),
+            """{ACTIVATION1: INPUT (None) -> [OPERATOR1 (None)] size=10: (1, 2), WEIGHT_REF1: WEIGHT1 (stateful_node) -> [OPERATOR1 (None), WEIGHT1_snk (stateful_node_sink)] size=123: (1, 4), WEIGHT_REF2: WEIGHT2 (stateful_node) -> [OPERATOR2 (None), WEIGHT2_snk (stateful_node_sink)] size=321: (1, 4), ACTIVATION2: OPERATOR1 (None) -> [OPERATOR2 (None)] size=30: (2, 3), OUTPUT_EDGE: OPERATOR2 (None) -> [OUTPUT (None)] size=50: (3, 4)}""",
+        )
+
+        spans = (makespan, asap, alap)
+        timesteps = defaultdict(lambda: [])
+        timesteps_with_start_offset = defaultdict(lambda: [])
+        for e in g.edges.values():
+            if not e.is_stateful():
+                continue
+            for t in s.TimeStepsForEdge(e, spans):
+                timesteps[str(e)].append(t)
+            for t in s.TimeStepsForEdge(e, spans, startoffset=1):
+                timesteps_with_start_offset[str(e)].append(t)
+
+        print(str(timesteps))
+        self.assertEqual(
+            timesteps,
+            {
+                "WEIGHT_REF1: WEIGHT1 (stateful_node) -> [OPERATOR1 (None), WEIGHT1_snk (stateful_node_sink)] size=123": [
+                    1,
+                    2,
+                    4,
+                ],
+                "WEIGHT_REF2: WEIGHT2 (stateful_node) -> [OPERATOR2 (None), WEIGHT2_snk (stateful_node_sink)] size=321": [
+                    1,
+                    2,
+                    3,
+                    4,
+                ],
+            },
+        )
+
+        print(str(timesteps_with_start_offset))
+        self.assertEqual(
+            timesteps_with_start_offset,
+            {
+                "WEIGHT_REF1: WEIGHT1 (stateful_node) -> [OPERATOR1 (None), WEIGHT1_snk (stateful_node_sink)] size=123": [
+                    2,
+                    4,
+                ],
+                "WEIGHT_REF2: WEIGHT2 (stateful_node) -> [OPERATOR2 (None), WEIGHT2_snk (stateful_node_sink)] size=321": [
+                    2,
+                    3,
+                    4,
+                ],
+            },
+        )
+
+        timesteps = defaultdict(lambda: [])
+        for n in g.nodes.values():
+            for t in s.TimeStepsForFanin(n, spans):
+                timesteps[n.name].append(t)
+        print(str(timesteps))
+        self.assertEqual(
+            timesteps,
+            {
+                "OPERATOR1": [1, 2],
+                "OPERATOR2": [2, 3],
+                "OUTPUT": [3, 4],
+                "WEIGHT1_snk": [1, 2, 4],
+                "WEIGHT2_snk": [1, 2, 3, 4],
+            },
+        )
+
+    def testAdvancedTimestepIterators(self):
+        g = graph_with_bmmadd.graph
+
+        s = training_graph_optimizer.Scheduler(g, timestep_factor=1)
+        asap = s.ComputeASAPSchedule({})
+        alap = s.ComputeALAPSchedule({}, max_timesteps=s.num_nodes)
+        makespan = s.ComputeMakespans(asap, alap)
+
+        # print(str(makespan))
+        self.assertEqual(
+            str(makespan),
+            """{ACTIVATION1: INPUT (None) -> [OPERATOR1 (None)] size=20: (1, 5), ACTIVATION7: INPUT2 (None) -> [OPERATOR6 (None)] size=110: (1, 5), WEIGHT_REF1: WEIGHT (stateful_node) -> [BMMADD (None), WEIGHT_snk (stateful_node_sink)] size=193: (1, 11), TRANSPOSE: BIAS (stateful_node) -> [TRANSPOSE (None), BIAS_snk (stateful_node_sink)] size=331: (1, 11), WEIGHT_TRANSPOSED: TRANSPOSE (None) -> [BMMADD (None)] size=60: (2, 8), ACTIVATION2: OPERATOR1 (None) -> [OPERATOR2 (None)] size=30: (2, 6), ACTIVATION3: OPERATOR2 (None) -> [OPERATOR3 (None)] size=40: (3, 7), ACTIVATION4: OPERATOR3 (None) -> [BMMADD (None)] size=50: (4, 8), ACTIVATION6: OPERATOR4 (None) -> [OPERATOR5 (None)] size=90: (6, 10), OUTPUT_EDGE: OPERATOR5 (None) -> [OUTPUT (None)] size=100: (7, 11), ACTIVATION8: OPERATOR6 (None) -> [OPERATOR2 (None)] size=120: (2, 6), ACTIVATION5: BMMADD (None) -> [OPERATOR4 (None)] size=80: (5, 9)}""",
+        )
+
+        spans = (makespan, asap, alap)
+        timesteps = defaultdict(lambda: [])
+        timesteps_with_start_offset = defaultdict(lambda: [])
+        for e in g.edges.values():
+            for t in s.TimeStepsForEdge(e, spans):
+                timesteps[str(e)].append(t)
+            for t in s.TimeStepsForEdge(e, spans, startoffset=1):
+                timesteps_with_start_offset[str(e)].append(t)
+
+        print(str(timesteps))
+        self.assertEqual(
+            timesteps,
+            {
+                "TRANSPOSE: BIAS (stateful_node) -> [TRANSPOSE (None), BIAS_snk (stateful_node_sink)] size=331": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    11,
+                ],
+                "ACTIVATION1: INPUT (None) -> [OPERATOR1 (None)] size=20": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                ],
+                "ACTIVATION2: OPERATOR1 (None) -> [OPERATOR2 (None)] size=30": [
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                ],
+                "ACTIVATION3: OPERATOR2 (None) -> [OPERATOR3 (None)] size=40": [
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                ],
+                "ACTIVATION4: OPERATOR3 (None) -> [BMMADD (None)] size=50": [
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                ],
+                "WEIGHT_TRANSPOSED: TRANSPOSE (None) -> [BMMADD (None)] size=60": [
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                ],
+                "WEIGHT_REF1: WEIGHT (stateful_node) -> [BMMADD (None), WEIGHT_snk (stateful_node_sink)] size=193": [
+                    1,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    11,
+                ],
+                "ACTIVATION5: BMMADD (None) -> [OPERATOR4 (None)] size=80": [
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                ],
+                "ACTIVATION6: OPERATOR4 (None) -> [OPERATOR5 (None)] size=90": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                ],
+                "OUTPUT_EDGE: OPERATOR5 (None) -> [OUTPUT (None)] size=100": [
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                ],
+                "ACTIVATION7: INPUT2 (None) -> [OPERATOR6 (None)] size=110": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                ],
+                "ACTIVATION8: OPERATOR6 (None) -> [OPERATOR2 (None)] size=120": [
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                ],
+            },
+        )
+
+        print(str(timesteps_with_start_offset))
+        self.assertEqual(
+            timesteps_with_start_offset,
+            {
+                "TRANSPOSE: BIAS (stateful_node) -> [TRANSPOSE (None), BIAS_snk (stateful_node_sink)] size=331": [
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    11,
+                ],
+                "ACTIVATION1: INPUT (None) -> [OPERATOR1 (None)] size=20": [2, 3, 4, 5],
+                "ACTIVATION2: OPERATOR1 (None) -> [OPERATOR2 (None)] size=30": [
+                    3,
+                    4,
+                    5,
+                    6,
+                ],
+                "ACTIVATION3: OPERATOR2 (None) -> [OPERATOR3 (None)] size=40": [
+                    4,
+                    5,
+                    6,
+                    7,
+                ],
+                "ACTIVATION4: OPERATOR3 (None) -> [BMMADD (None)] size=50": [
+                    5,
+                    6,
+                    7,
+                    8,
+                ],
+                "WEIGHT_TRANSPOSED: TRANSPOSE (None) -> [BMMADD (None)] size=60": [
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                ],
+                "WEIGHT_REF1: WEIGHT (stateful_node) -> [BMMADD (None), WEIGHT_snk (stateful_node_sink)] size=193": [
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    11,
+                ],
+                "ACTIVATION5: BMMADD (None) -> [OPERATOR4 (None)] size=80": [
+                    6,
+                    7,
+                    8,
+                    9,
+                ],
+                "ACTIVATION6: OPERATOR4 (None) -> [OPERATOR5 (None)] size=90": [
+                    7,
+                    8,
+                    9,
+                    10,
+                ],
+                "OUTPUT_EDGE: OPERATOR5 (None) -> [OUTPUT (None)] size=100": [
+                    8,
+                    9,
+                    10,
+                    11,
+                ],
+                "ACTIVATION7: INPUT2 (None) -> [OPERATOR6 (None)] size=110": [
+                    2,
+                    3,
+                    4,
+                    5,
+                ],
+                "ACTIVATION8: OPERATOR6 (None) -> [OPERATOR2 (None)] size=120": [
+                    3,
+                    4,
+                    5,
+                    6,
+                ],
+            },
+        )
+
+        timesteps = defaultdict(lambda: [])
+        for n in g.nodes.values():
+            for t in s.TimeStepsForFanin(n, spans):
+                timesteps[n.name].append(t)
+
+        print(str(timesteps))
+        self.assertEqual(
+            timesteps,
+            {
+                "TRANSPOSE": [1, 2, 3, 4, 5, 6, 7, 11],
+                "OPERATOR1": [1, 2, 3, 4, 5],
+                "OPERATOR2": [2, 3, 4, 5, 6],
+                "OPERATOR3": [3, 4, 5, 6, 7],
+                "OPERATOR4": [5, 6, 7, 8, 9],
+                "OPERATOR5": [6, 7, 8, 9, 10],
+                "OPERATOR6": [1, 2, 3, 4, 5],
+                "BMMADD": [4, 5, 6, 7, 8],
+                "OUTPUT": [7, 8, 9, 10, 11],
+                "WEIGHT_snk": [1, 4, 5, 6, 7, 8, 11],
+                "BIAS_snk": [1, 2, 3, 4, 5, 6, 7, 11],
+            },
+        )
+
+        timesteps = defaultdict(lambda: [])
+        for n in g.nodes.values():
+            if n.is_stateful():
+                continue
+            for t in s.TimeStepsForNode(n, spans):
+                timesteps[n.name].append(t)
+
+        print(str(timesteps))
+        self.assertEqual(
+            timesteps,
+            {
+                "INPUT": [1, 2, 3, 4],
+                "INPUT2": [1, 2, 3, 4],
+                "TRANSPOSE": [2, 3, 4, 5, 6, 7],
+                "OPERATOR1": [2, 3, 4, 5],
+                "OPERATOR2": [3, 4, 5, 6],
+                "OPERATOR3": [4, 5, 6, 7],
+                "OPERATOR4": [6, 7, 8, 9],
+                "OPERATOR5": [7, 8, 9, 10],
+                "OPERATOR6": [2, 3, 4, 5],
+                "BMMADD": [5, 6, 7, 8],
+                "OUTPUT": [8, 9, 10, 11],
+            },
+        )
+
+    def testDensePreserveVarsMap(self):
+        sparse_ts = {1: "A", 2: "B", 5: "C", 6: "D", 8: "E"}
+        dense_map = training_graph_optimizer.Scheduler.DensePreserveVarsMap(sparse_ts)
+
+        dense_ts = {}
+        for i in range(1, 9):
+            dense_ts[i] = dense_map[i]
+        print(str(dense_ts))
+        self.assertEqual(
+            dense_ts, {1: "A", 2: "B", 3: "C", 4: "C", 5: "C", 6: "D", 7: "E", 8: "E"}
+        )
+
+    def testDenseGenerateOrFetchVarsMap(self):
+        sparse_ts = {1: "A", 2: "B", 5: "C", 6: "D", 8: "E"}
+        dense_map = training_graph_optimizer.Scheduler.DenseGenerateOrFetchVarsMap(
+            sparse_ts
+        )
+
+        dense_ts = {}
+        for i in range(1, 9):
+            dense_ts[i] = dense_map[i]
+        print(str(dense_ts))
+        self.assertEqual(
+            dense_ts, {1: "A", 2: "B", 3: 0, 4: 0, 5: "C", 6: "D", 7: 0, 8: "E"}
+        )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,45 @@
+import unittest
+
+from olla import dataflow_graph, utils
+from olla.native_graphs import graph_with_weights
+
+
+class UtilsTest(unittest.TestCase):
+    def setUp(self):
+        self.t1 = dataflow_graph.Edge(None, [], name="e1", size=128)
+        self.t2 = dataflow_graph.Edge(None, [], name="e2", size=128)
+
+    def testLineNumber(self):
+        ln = utils.get_linenumber()
+        self.assertEqual(ln, 13)
+
+    def testExtractNodeOrdering(self):
+        g = graph_with_weights.graph
+
+        schedule = {
+            g.edges["ACTIVATION_EDGE"]: ([1], [2], []),
+            g.edges["WEIGHT_EDGE"]: ([1], [2, 3], []),
+            g.edges["OUTPUT_EDGE"]: ([2], [], []),
+        }
+        ordering = utils.extract_node_ordering(g, schedule)
+        print("ORDERING: " + str(ordering))
+        self.assertEqual(
+            str(ordering),
+            """{INPUT (None): 1, WEIGHT (stateful_node): 1, OPERATOR (None): 2, OUTPUT (None): 3}""",
+        )
+
+    def testValidMem(self):
+        mem = {
+            1: {self.t1: 0, self.t2: 256},
+            2: {self.t1: 0, self.t2: 256},
+            3: {self.t1: 0, self.t2: 128},
+        }
+        self.assertTrue(utils.validate_address_allocation(mem))
+
+    def testInvalidMem(self):
+        mem = {
+            1: {self.t1: 0, self.t2: 64},
+            2: {self.t1: 0, self.t2: 64},
+            3: {self.t1: 0, self.t2: 256},
+        }
+        self.assertFalse(utils.validate_address_allocation(mem))


### PR DESCRIPTION
Did the following changes to our internal code:
- used `import olla` instead of the `import <fb code internal code path>`
- removed dependency of `ilp_solver.py` on internal wrapper libraries
- moved tests to dedicated `tests` directory
- added steps to install in README

Caveats:
- running scheduler on most benchmarks (except AlexNet) will fail without Gurobi license as they are too large
- some unit test cases that are small enough to run on free Gurobi return different results (that are indeed suboptimal) from running with Gurobi license
- `acc_tracer` directory was for now copied and pasted from github.com/pytorch/TensorRT repo. Maybe we should include it properly as a git submodule