### PR TITLE
Properly skip failing tests

### DIFF
--- a/tests/defragmenter_test.py
+++ b/tests/defragmenter_test.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from olla import dataflow_graph, defragmenter
 
@@ -25,6 +26,7 @@ class DefragmenterTest(unittest.TestCase):
         l = [(e.name, a) for e, a in layout.items()]
         self.assertEqual(l, [("a", 0.0), ("b", 23.0)])
 
+    @unittest.skipIf(not bool(os.getenv('RUN_SKIPPED', 0)), "Fails, TODO: @melhoushi")
     def testMixed(self):
         defrag = defragmenter.Defragmenter()
         spans = {}

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from olla import scheduler, utils
 from olla.native_graphs import (
@@ -12,9 +13,6 @@ from olla.native_graphs import (
 
 
 class SchedulerTest(unittest.TestCase):
-    def setUp(self):
-        pass
-
     def testNonFragmentation(self):
         g = simple_graph.graph
 

--- a/tests/spill_profiler_test.py
+++ b/tests/spill_profiler_test.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import torch
 
@@ -7,6 +8,7 @@ from olla.torch import spill_profiler
 
 
 class SpillProfilterTest(unittest.TestCase):
+    @unittest.skipIf(not bool(os.getenv('RUN_SKIPPED', 0)), "Spilling implementation not yet fully-complete")
     def testBasic(self):
         g = graph_with_gradients.graph
         profiler = spill_profiler.SpillProfiler(g, warm_up_iters=1, profile_iters=10)

--- a/tests/torch_graph_importer_test.py
+++ b/tests/torch_graph_importer_test.py
@@ -1054,6 +1054,7 @@ MultiSourceEdge getitem_10:0_opt, size:5440, mem_space:None, tile_id:None group_
         not torch.cuda.is_available(),
         "Memory profiling currently only works with CUDA",
     )
+    @unittest.skipIf(not bool(os.getenv('RUN_SKIPPED', 0)), "Fails with some non-stable fx versions. Enable after fixing a PyTorch/fx version")
     def testImportWithMemoryProfile(self):
         class SimpleModule(torch.nn.Module):
             def __init__(self):

--- a/tests/training_graph_optimizer_large_test.py
+++ b/tests/training_graph_optimizer_large_test.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from olla import training_graph_optimizer, utils
 from olla.native_graphs import graph_with_gradients
@@ -8,6 +9,7 @@ class SchedulerTest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 
+    @unittest.skipIf(not bool(os.getenv('RUN_SKIPPED', 0)), "Temporarily disabled; TODO: @melhoushi")
     def testGraphWithGradients(self):
         g = graph_with_gradients.graph
 


### PR DESCRIPTION
See title.

Adds an env var `RUN_SKIPPED` which runs skipped tests if enabled. Native Python `unittest` doesn't support skipping running tests. Add the skip annotation for anything that's failing, for now.