### PR TITLE
Add interface for initializing Gurobi

### DIFF
--- a/olla/gurobi_utils.py
+++ b/olla/gurobi_utils.py
@@ -1,0 +1,28 @@
+import gurobipy
+import os
+import logging
+
+
+def get_gurobi_env():
+    try:
+        # Try using an ISV license based on the supplied environment variables
+        env = gurobipy.Env.OtherEnv(
+            os.getenv("OLLA_GUROBI_LOGFILE", ""),
+            os.getenv("OLLA_GUROBI_ISV_NAME"),
+            os.getenv("OLLA_GUROBI_ISV_APP_NAME"),
+            int(os.getenv("OLLA_GUROBI_ISV_EXPIRATION")),
+            os.getenv("OLLA_GUROBI_ISV_CODE"),
+        )
+        logging.info("Successfully created Gurobi env with ISV license")
+    except:
+        logging.warning(
+            "Failed to create env based on ISV license. If you intended to use",
+            " an ISV license, set the OLLA_GUROBI_ISV_NAME",
+            " OLLA_GUROBI_ISV_APP_NAME, OLLA_GUROBI_ISV_EXPIRATION,",
+            " and OLLA_GUROBI_ISV_CODE to their corresponding values."
+            " Falling back to default Gurobi environment initialization.",
+        )
+        # Fall back to default env
+        env = gurobipy.Env()
+
+    return env

--- a/olla/ilp_solver.py
+++ b/olla/ilp_solver.py
@@ -2,6 +2,7 @@ import sys
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 from dataclasses import dataclass
+from olla.gurobi_utils import get_gurobi_env
 
 import gurobipy as gr
 
@@ -31,7 +32,7 @@ class ILPSolver:
         self.extra_params = extra_params
         self.num_constraints = 0
         if solver == "GUROBI" or solver == "gurobi":
-            self.model = gr.Model("gurobi")
+            self.model = gr.Model("gurobi", env=get_gurobi_env())
         else:
             raise Exception("Currently only Gurobi solver is supported.")
         self._message_callback = None


### PR DESCRIPTION
Since many users are using Gurobi licenses that aren't ISV, don't assume anything about how Gurobi will initialize its env. Fall back to the default environment initialization if ISV license initialization fails.

This allows or Gurobi interoperability in open source environments, internally, and in CI with environment secrets.

Defines environment variables to initialize an ISV license as follows:
```
OLLA_GUROBI_ISV_NAME
OLLA_GUROBI_ISV_APP_NAME
OLLA_GUROBI_ISV_EXPIRATION
OLLA_GUROBI_ISV_CODE
```
as well as a `OLLA_GUROBI_LOGFILE` environment variable that can be used to specify a logfile path for Gurobi.