### PR TITLE
Fix OLLA APIs

### DIFF
--- a/olla/apis.py
+++ b/olla/apis.py
@@ -17,9 +17,8 @@ def extract_tensors_and_params(results):
 
     return outputs, params
 
-# TODO: support evaluation
 # TODO: add options to enable/disable node ordering, defragmentation, etc.
-def optimize(model, inputs, loss_fn, optimizer):
+def optimize(model, inputs, loss_fn=None, optimizer=None):
     # import fx graph and data flow graph
     importer = torch_graph_importer.TorchGraphImporter()
     (

--- a/tests/fx_optimizer_test.py
+++ b/tests/fx_optimizer_test.py
@@ -12,6 +12,8 @@ class FXOptimizerTest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 
+    # TODO: Test import_via_fx, import_via_acc_tracer, import_via_functorch?
+
     def testSimpleModule(self):
         class SimpleModule(torch.nn.Module):
             def __init__(self):

--- a/tests/olla_apis_test.py
+++ b/tests/olla_apis_test.py
@@ -5,6 +5,28 @@ import unittest
 import olla
 
 class OLLAAPIsTest(unittest.TestCase):
+    def testSimpleEval(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.randn((1,)), requires_grad=True)
+
+            def forward(self, x):
+                return x + self.param + 5
+
+        model = SimpleModule()
+        input = torch.randn((1), requires_grad=False)
+
+        model_opt = olla.optimize(model, input)
+
+        y_orig = model(input)
+        y = model_opt(input)
+        assert(torch.allclose(y, y_orig))
+
+        y2 = model_opt(input)
+        # since this is inference mode, everytime we run the model with same input, we should get same output
+        assert(torch.allclose(y, y2))
+
     def testSimpleTrain(self):
         class SimpleModule(torch.nn.Module):
             def __init__(self):
@@ -15,7 +37,7 @@ class OLLAAPIsTest(unittest.TestCase):
                 return x + self.param + 5
 
         model = SimpleModule()
-        input = torch.randn((1), requires_grad = True)
+        input = torch.randn((1), requires_grad=True)
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss_fn = torch.nn.MSELoss()
 
@@ -31,7 +53,7 @@ class OLLAAPIsTest(unittest.TestCase):
 
     def testAlexNetTrain(self):
         model = torchvision.models.alexnet()
-        input = torch.randn((32, 3, 224, 224), requires_grad = True)
+        input = torch.randn((32, 3, 224, 224), requires_grad=True)
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss_fn = torch.nn.MSELoss()
 

--- a/tests/olla_apis_test.py
+++ b/tests/olla_apis_test.py
@@ -120,8 +120,8 @@ class OLLAAPIsTest(unittest.TestCase):
         assert(torch.allclose(y2_orig, y_orig))
         assert(torch.allclose(y, y2))
 
-    def testAlexNetTrain(self):
-        model = torchvision.models.alexnet()
+    def testResNet18Train(self):
+        model = torchvision.models.resnet18()
         input = torch.randn((32, 3, 224, 224), requires_grad=True)
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss_fn = torch.nn.MSELoss()
@@ -131,8 +131,7 @@ class OLLAAPIsTest(unittest.TestCase):
 
         y_orig = model(input)
         y = model_opt(input)
-        # FIXME: Assertion failing
-        # assert(torch.allclose(y, y_orig))
+        assert(torch.allclose(y, y_orig))
 
         y2 = model_opt(input)
         # everytime we run the model, the weights get updated, so we expect the output to be different

--- a/tests/olla_apis_test.py
+++ b/tests/olla_apis_test.py
@@ -17,6 +17,7 @@ class OLLAAPIsTest(unittest.TestCase):
         model = SimpleModule()
         input = torch.randn((1), requires_grad=False)
 
+        model.eval()
         model_opt = olla.optimize(model, input)
 
         y_orig = model(input)
@@ -41,6 +42,7 @@ class OLLAAPIsTest(unittest.TestCase):
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss_fn = torch.nn.MSELoss()
 
+        model.train()
         model_opt = olla.optimize(model, input, optimizer=optimizer, loss_fn=loss_fn)
 
         y_orig = model(input)
@@ -64,6 +66,7 @@ class OLLAAPIsTest(unittest.TestCase):
         model = SimpleModule()
         input = torch.randn((3, 4), requires_grad=False)
 
+        model.eval()
         model_opt = olla.optimize(model, input)
 
         y_orig = model(input)
@@ -89,6 +92,7 @@ class OLLAAPIsTest(unittest.TestCase):
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss_fn = torch.nn.MSELoss()
 
+        model.train()
         model_opt = olla.optimize(model, input, optimizer=optimizer, loss_fn=loss_fn)
 
         y_orig = model(input)
@@ -122,6 +126,7 @@ class OLLAAPIsTest(unittest.TestCase):
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         loss_fn = torch.nn.MSELoss()
 
+        model.train()
         model_opt = olla.optimize(model, input, optimizer=optimizer, loss_fn=loss_fn)
 
         y_orig = model(input)

--- a/tests/olla_apis_test.py
+++ b/tests/olla_apis_test.py
@@ -99,6 +99,23 @@ class OLLAAPIsTest(unittest.TestCase):
         # everytime we run the model, the weights get updated, so we expect the output to be different
         assert(not torch.allclose(y, y2))
 
+    def testAlexNetEval(self):
+        model = torchvision.models.alexnet()
+        input = torch.randn((1, 3, 224, 224), requires_grad=False)
+
+        model.eval()
+        model_opt = olla.optimize(model, input)
+
+        y_orig = model(input)
+        y = model_opt(input)
+        assert(torch.allclose(y, y_orig))
+
+        y2_orig = model(input)
+        y2 = model_opt(input)
+        # since this is inference mode, everytime we run the model with same input, we should get same output
+        assert(torch.allclose(y2_orig, y_orig))
+        assert(torch.allclose(y, y2))
+
     def testAlexNetTrain(self):
         model = torchvision.models.alexnet()
         input = torch.randn((32, 3, 224, 224), requires_grad=True)

--- a/tests/olla_apis_test.py
+++ b/tests/olla_apis_test.py
@@ -5,6 +5,30 @@ import unittest
 import olla
 
 class OLLAAPIsTest(unittest.TestCase):
+    def testSimpleTrain(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.param = torch.nn.Parameter(torch.randn((1,)), requires_grad=True)
+
+            def forward(self, x):
+                return x + self.param + 5
+
+        model = SimpleModule()
+        input = torch.randn((1), requires_grad = True)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        loss_fn = torch.nn.MSELoss()
+
+        model_opt = olla.optimize(model, input, optimizer=optimizer, loss_fn=loss_fn)
+
+        y_orig = model(input)
+        y = model_opt(input)
+        assert(torch.allclose(y, y_orig))
+
+        y2 = model_opt(input)
+        # everytime we run the model, the weights get updated, so we expect the output to be different
+        assert(not torch.allclose(y, y2))
+
     def testAlexNetTrain(self):
         model = torchvision.models.alexnet()
         input = torch.randn((32, 3, 224, 224), requires_grad = True)

--- a/tests/olla_apis_test.py
+++ b/tests/olla_apis_test.py
@@ -5,7 +5,7 @@ import unittest
 import olla
 
 class OLLAAPIsTest(unittest.TestCase):
-    def testSimpleEval(self):
+    def testTrivialEval(self):
         class SimpleModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -27,7 +27,7 @@ class OLLAAPIsTest(unittest.TestCase):
         # since this is inference mode, everytime we run the model with same input, we should get same output
         assert(torch.allclose(y, y2))
 
-    def testSimpleTrain(self):
+    def testTrivialTrain(self):
         class SimpleModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -50,6 +50,29 @@ class OLLAAPIsTest(unittest.TestCase):
         y2 = model_opt(input)
         # everytime we run the model, the weights get updated, so we expect the output to be different
         assert(not torch.allclose(y, y2))
+
+    def testSimpleEval(self):
+        class SimpleModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(4, 5)
+                self.linear2 = torch.nn.Linear(4, 5)
+
+            def forward(self, x):
+                return self.linear1(x) + self.linear2(x)
+
+        model = SimpleModule()
+        input = torch.randn((3, 4), requires_grad=False)
+
+        model_opt = olla.optimize(model, input)
+
+        y_orig = model(input)
+        y = model_opt(input)
+        assert(torch.allclose(y, y_orig))
+
+        y2 = model_opt(input)
+        # since this is inference mode, everytime we run the model with same input, we should get same output
+        assert(torch.allclose(y, y2))
 
     def testAlexNetTrain(self):
         model = torchvision.models.alexnet()


### PR DESCRIPTION
Added more tests (small, and larger models) and ensured that output of original `model` and `olla.optimize(model)` are the same.

Also added more args and handled them inside `olla.optimize`

There is an issue with AlexNet that has Dropout which causes outputs to be different.
But other models like ResNet18 are fine.

Test Plan:
```
python -m unittest tests/olla_apis_test.py
```