### PR TITLE
maximize sequene length of text models

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -132,7 +132,7 @@ class Benchmark:
             max_seq_len = 512
             text = "Hello world"
             # Repeat text to fill maximum sequence length of model
-            text = text * max_seq_len // len(text.split())
+            text = text * (max_seq_len // len(text.split()))
             input_batch = [text] * batch_size
             inputs = (
                 torchtext.functional.to_tensor(transform(input_batch), padding_value=1),
@@ -179,7 +179,7 @@ class Benchmark:
             max_seq_len = 1024
             text = "Hello world"
             # Repeat text to fill maximum sequence length of model
-            text = text * max_seq_len // len(text.split())
+            text = text * (max_seq_len // len(text.split()))
             input_batch = [text] * batch_size
             inputs = (
                 torchtext.functional.to_tensor(transform(input_batch), padding_value=1),
@@ -198,7 +198,7 @@ class Benchmark:
             max_seq_len = 1024
             text = "Replace me by any text you'd like."
             # Repeat text to fill maximum sequence length of model
-            text = text * max_seq_len // len(text.split())
+            text = text * (max_seq_len // len(text.split()))
             input_batch = [text] * batch_size
             tokens = tokenizer.tokenize(text)
             indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -129,7 +129,7 @@ class Benchmark:
             bert_base = torchtext.models.ROBERTA_BASE_ENCODER
             model = bert_base.get_model()
             transform = bert_base.transform()
-            max_seq_len = 1024
+            max_seq_len = 512
             text = "Hello world"
             # Repeat text to fill maximum sequence length of model
             text = text * max_seq_len // len(text.split())

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -129,7 +129,11 @@ class Benchmark:
             bert_base = torchtext.models.ROBERTA_BASE_ENCODER
             model = bert_base.get_model()
             transform = bert_base.transform()
-            input_batch = ["Hello world"] * batch_size
+            max_seq_len = 1024
+            text = "Hello world"
+            # Repeat text to fill maximum sequence length of model
+            text = text * max_seq_len // len(text.split())
+            input_batch = [text] * batch_size
             inputs = (
                 torchtext.functional.to_tensor(transform(input_batch), padding_value=1),
             )
@@ -172,7 +176,11 @@ class Benchmark:
             xlmr_base = torchtext.models.XLMR_BASE_ENCODER
             model = xlmr_base.get_model()
             transform = xlmr_base.transform()
-            input_batch = ["Hello world"] * batch_size
+            max_seq_len = 1024
+            text = "Hello world"
+            # Repeat text to fill maximum sequence length of model
+            text = text * max_seq_len // len(text.split())
+            input_batch = [text] * batch_size
             inputs = (
                 torchtext.functional.to_tensor(transform(input_batch), padding_value=1),
             )

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -195,7 +195,11 @@ class Benchmark:
                 def forward(self, x):
                     return self.model(x).last_hidden_state
             tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+            max_seq_len = 1024
             text = "Replace me by any text you'd like."
+            # Repeat text to fill maximum sequence length of model
+            text = text * max_seq_len // len(text.split())
+            input_batch = [text] * batch_size
             tokens = tokenizer.tokenize(text)
             indexed_tokens = tokenizer.convert_tokens_to_ids(tokens)
             inputs = torch.tensor([indexed_tokens])

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -571,7 +571,7 @@ if __name__ == "__main__":
                         infer_trace=args.verify_node_ordering,
                     )
                 except Exception as e:
-                    print(f"  FAILED TO LOAD {model}, SKIPPING TO NEXT MODEL: {e}")
+                    print(f"  FAILED TO LOAD {model}, SKIPPING TO NEXT MODEL:\n{traceback.format_exc()}")
                     result["load_model.error"] = str(e).replace("\n", " ")
                     continue
 
@@ -640,7 +640,7 @@ if __name__ == "__main__":
                                 result["node_ordering.verification"] = "SUCCESS"
                             except Exception as e:
                                 print(
-                                    f"  FAILED TO VERIFY REORDERED NODES: {e}",
+                                    f"  FAILED TO VERIFY REORDERED NODES:\n{traceback.format_exc()}",
                                     flush=True,
                                 )
                                 result["node_ordering.verification"] = "FAIL"
@@ -680,7 +680,7 @@ if __name__ == "__main__":
                                 ] = profiler.peak_reserved_bytes
                             except Exception as e:
                                 print(
-                                    f"  FAILED TO PROFILE REORDERED NODES: {e}",
+                                    f"  FAILED TO PROFILE REORDERED NODES:\n{traceback.format_exc()}",
                                     flush=True,
                                 )
                                 result["node_ordering.profile"] = "FAIL"
@@ -689,7 +689,7 @@ if __name__ == "__main__":
                                 )
 
                     except Exception as e:
-                        print(f"  FAILED TO REORDER NODES: {e}", flush=True)
+                        print(f"  FAILED TO REORDER NODES:\n{traceback.format_exc()}", flush=True)
                         result["node_ordering.error"] = str(e).replace("\n", " ")
                         continue
 
@@ -714,7 +714,7 @@ if __name__ == "__main__":
                         result["address_generation.fragmentation"] = fragmentation
                         result["address_generation.peak_mem_usage"] = peak_mem_usage
                     except Exception as e:
-                        print(f"  FAILED TO GENERATE ADDRESSES: {e}", flush=True)
+                        print(f"  FAILED TO GENERATE ADDRESSES:\n{traceback.format_exc()}", flush=True)
                         result["address_generation.error"] = str(e).replace("\n", " ")
                         traceback.print_exc()
 
@@ -752,7 +752,7 @@ if __name__ == "__main__":
                                 break
                     except Exception as e:
                         print(
-                            f"  FAILED TO PLAN REMATERIALIZATION TO SAVE {savings*100}% MEMORY: {e}",
+                            f"  FAILED TO PLAN REMATERIALIZATION TO SAVE {savings*100}% MEMORY:\n{traceback.format_exc()}",
                             flush=True,
                         )
                         result[f"rematerialization.savings_{savings}.error"] = str(
@@ -792,7 +792,7 @@ if __name__ == "__main__":
                                 break
                     except Exception as e:
                         print(
-                            f"  FAILED TO PLAN SPILLING TO SAVE {savings*100}% MEMORY: {e}",
+                            f"  FAILED TO PLAN SPILLING TO SAVE {savings*100}% MEMORY:\n{traceback.format_exc()}",
                             flush=True,
                         )
                         result[f"spilling.savings_{savings}.error"] = str(e).replace(


### PR DESCRIPTION
This is in order to maximize GPU memory usage

Test Plan:
```
python benchmarks.py --model bert -b 1 --memory-profile --modes eval; python benchmarks.py --model bert -b 1 --memory-profile --modes train --append; 
python benchmarks.py --model bert -b 32 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 32 --memory-profile --modes train --append; 
python benchmarks.py --model bert -b 64 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 64 --memory-profile --modes train --append;
python benchmarks.py --model bert -b 128 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 128 --memory-profile --modes train --append;
python benchmarks.py --model bert -b 256 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 256 --memory-profile --modes train --append;
python benchmarks.py --model bert -b 512 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 512 --memory-profile --modes train --append;
python benchmarks.py --model bert -b 1024 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 1024 --memory-profile --modes train --append;
python benchmarks.py --model bert -b 2048 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 2048 --memory-profile --modes train --append;
python benchmarks.py --model bert -b 4096 --memory-profile --modes eval --append; python benchmarks.py --model bert -b 4096 --memory-profile --modes train --append;
```

Results before this PR:
|model|mode|batch_size|profile.max_mem_fragmentation|profile.peak_mem_usage|profile.allocated_mem_at_peak|simulated.peak_mem_usage|node_ordering.solver_time|node_ordering.peak_mem_usage|
|-----|----|----------|-----------------------------|----------------------|-----------------------------|------------------------|-------------------------|----------------------------|
|bert |eval|1         |0.06912612915039062          |536870912             |499759104                    |496327684               |1.8723771572113037       |496327684.0                 |
|bert |train|1         |0.3797867519403595           |1604321280            |995021312                    |992446496               |3.5513577461242676       |650643488.0                 |
|bert |eval|32        |0.03373937774122807          |597688320             |577522688                    |499756160               |3.868647336959839        |499763840.0                 |
|bert |train|32        |0.4036264084092337           |1669332992            |995546112                    |992828416               |20.70379066467285        |651025408.0                 |
|bert |eval|64        |0.11583446557971014          |723517440             |639709184                    |503295232               |3.920713424682617        |503310592.0                 |
|bert |train|64        |0.43629108694051827          |1780482048            |1003673600                   |993222656               |13.371329545974731       |673758208.0                 |
|bert |eval|128       |0.04206370344065657          |830472192             |795539456                    |510373376               |3.8930447101593018       |510404096.0                 |
|bert |train|128       |0.39532339195183774          |1654652928            |1000529920                   |994011136               |12.158321857452393       |841862144.0                 |
|bert |eval|256       |0.13084768963675214          |1226833920            |1066305536                   |524529664               |3.905106544494629        |524591104.0                 |
|bert |train|256       |0.4939504794973545           |1981808640            |1002893312                   |1190659072              |7.124819040298462        |1178070016.0                |
|bert |eval|512       |0.09550260114559164          |1807745024            |1635100672                   |552842240               |3.640626907348633        |552842240.0                 |
|bert |train|512       |0.6190234375                 |2621440000            |998707200                    |1875657728              |10.06928277015686        |1859922944.0                |
|bert |eval|1024      |0.08405374461206896          |3040870400            |2785273856                   |609467392               |3.8178601264953613       |609713152.0                 |
|bert |train|1024      |0.7514404804443867           |4034920448            |1002917888                   |3245655040              |7.610780477523804        |3223628800.0                |
|bert |eval|2048      |0.0801319045527915           |5521801216            |5079328768                   |722717696               |4.59921932220459         |722717696.0                 |
|bert |train|2048      |0.8512091123784885           |6687817728            |995086336                    |5985649664              |6.080118417739868        |5951040512.0                |
|bert |eval|4096      |0.08605602993394915          |10557063168           |9648564224                   |949218304               |3.7538836002349854       |950201344.0                 |
|bert |train|4096      |0.9168718185158972           |12037652480           |1000668160                   |11465638912             |6.508470058441162        |11405863936.0               |


Results after this PR:
Fragmentation numbers are still high, but peak_mem_usage and allocated_mem_at_peak increased 10 to 18 times, and most of the tests fail with OOM error.

|model|mode|batch_size|profile.max_mem_fragmentation|profile.peak_mem_usage|profile.allocated_mem_at_peak|simulated.peak_mem_usage|node_ordering.solver_time|node_ordering.peak_mem_usage|
|-----|----|----------|-----------------------------|----------------------|-----------------------------|------------------------|-------------------------|----------------------------|
|bert |eval|1         |0.11330807864010989          |763363328             |676868096                    |504081664               |2.3799495697021484       |504081664.0                 |
|bert |train|1         |0.4443405062134503           |1793064960            |996333568                    |993222656               |6.3414716720581055       |757365760.0                 |
|bert |eval|32        |0.06948809744079153          |6729760768            |6262122496                   |747883520               |4.013092994689941        |747883520.0                 |
|bert |train|32        |0.8936814003076062           |9374269440            |996659200                    |8661091328              |6.422394275665283        |8626482176.0                |
|bert |eval|64        |0.06932912279901006          |12922650624           |12026734592                  |999549952               |3.9701380729675293       |999549952.0                 |


