### PR TITLE
Fix memory profiling

### DIFF
--- a/olla/torch/fx_profiler.py
+++ b/olla/torch/fx_profiler.py
@@ -42,6 +42,7 @@ class ProfilingInterpreter(torch.fx.Interpreter):
         self.table = None
         self.max_mem_fragmentation = None
         self.peak_reserved_bytes = None
+        self.allocated_mem_at_peak = None
 
     def run(self, *args) -> Any:
         # reset profile results and status variables

--- a/olla/torch/fx_profiler.py
+++ b/olla/torch/fx_profiler.py
@@ -116,7 +116,7 @@ class ProfilingInterpreter(torch.fx.Interpreter):
                     row["allocated_bytes.all.current"] = allocated_mem_at_max
                 else:
                     row[name] = statistics.mean(values)
-            self.table = self.table.append(row, ignore_index=True)
+            self.table.loc[len(self.table), row.keys()] = row.values()
 
         # ensure that the first 3 columns are: Op name, Op type, runtime
         self.table.insert(0, "Op name", self.table.pop("Op name"))

--- a/tests/fx_optimizer_test.py
+++ b/tests/fx_optimizer_test.py
@@ -164,26 +164,26 @@ class FXOptimizerTest(unittest.TestCase):
                 e5 = self.v2(e3)
                 e6 = self.v4(e4, e5)
                 return e6
-        
+
         class V1(torch.nn.Module):
-           def forward(self, e1):
-                e2 = e1
+            def forward(self, e1):
+                e2 = e1.clone()
                 e3 = torch.cat([e1, e1])
                 return e3, e2
-        
+
         class V2(torch.nn.Module):
-           def forward(self, e3):
-                e5 = e3[0:e3.numel()//4]
+            def forward(self, e3):
+                e5 = e3[0::4].clone()
                 return e5
-        
+
         class V3(torch.nn.Module):
-           def forward(self, e2):
+            def forward(self, e2):
                 e4 = torch.cat([e2, e2, e2])
                 return e4
-        
+
         class V4(torch.nn.Module):
-           def forward(self, e4, e5):
-                e6 = torch.cat([e5, e4[0:e4.numel()//6]])
+            def forward(self, e4, e5):
+                e6 = torch.cat([e5, e4[::6]])
                 return e6
     
         # custom tracer to treat V1, V2, V3, and V4 as ops and avoid tracing through them


### PR DESCRIPTION
- Fixed the test case
- Used another method to profile memory

Test:
```
python -m unittest tests.fx_optimizer_test.FXOptimizerTest.testPaperFigure3Schedule
```

Result:
```
Profiled allocated memory at peak before node ordering : 90.0
Profile allocated memory at peak after node ordering : 85.0
```

Running `./benchmarks.sh` for all benchmarks with batch sizes 1, 32, 64, 128, 256, 512, 1024, 2048:
|model           |mode |batch_size|profile.max_mem_fragmentation|profile.peak_mem_usage|profile.allocated_mem_at_peak|simulated.peak_mem_usage|node_ordering.solver_time|node_ordering.peak_mem_usage|
|----------------|-----|----------|-----------------------------|----------------------|-----------------------------|------------------------|-------------------------|----------------------------|
|alexnet         |eval |1         |0.05461774553571429          |264241152.0           |249808896.0                  |245779872               |0.04565000534057617      |245779872.0                 |
|alexnet         |eval |64        |0.23576811882062146          |742391808.0           |567359488.0                  |332500128               |0.047286272048950195     |332500128.0                 |
|alexnet         |eval |256       |0.37379562875214406          |2445279232.0          |1531244544.0                 |596790432               |0.04811906814575195      |596790432.0                 |
|alexnet         |eval |1024      |0.2594823344047963           |7258243072.0          |5374857216.0                 |1653951648              |0.04474759101867676      |1653951648.0                |
|alexnet         |eval |32        |0.20691167091836735          |513802240.0           |407490560.0                  |288451744               |0.04581308364868164      |288451744.0                 |
|alexnet         |eval |128       |0.34625555448222567          |1356857344.0          |887037952.0                  |420596896               |0.04699587821960449      |420596896.0                 |
|alexnet         |eval |512       |0.3907589944911404           |4615831552.0          |2812153856.0                 |949177504               |0.04953742027282715      |949177504.0                 |
|alexnet         |eval |2048      |0.24447522762403862          |13906214912.0         |10506489856.0                |3063499936              |0.04741716384887695      |3063499936.0                |
|alexnet         |train|1         |0.08241626550261097          |803209216.0           |737011712.0                  |491638848               |0.11450767517089844      |399079072.0                 |
|alexnet         |train|64        |0.23191658893034825          |1264582656.0          |971304960.0                  |724524096               |0.11700630187988281      |629935264.0                 |
|alexnet         |train|256       |0.2880680267467249           |2401239040.0          |1709518848.0                 |1461312576              |0.11562585830688477      |1333496992.0                |
|alexnet         |train|1024      |0.5529787123539485           |10410262528.0         |4653608960.0                 |4408466496              |0.11898374557495117      |4173941920.0                |
|alexnet         |train|32        |0.15703825445036382          |1008730112.0          |850320896.0                  |603195968               |0.11739158630371094      |512674976.0                 |
|alexnet         |train|128       |0.3704554322747014           |1931476992.0          |1215950848.0                 |970120256               |0.11925196647644043      |864455840.0                 |
|alexnet         |train|512       |0.44911392362601976          |4884267008.0          |2690674688.0                 |2443697216              |0.12237119674682617      |2271579296.0                |
|alexnet         |train|2048      |0.325341764687706            |12725518336.0         |8585375744.0                 |8338005056              |0.12097001075744629      |8103480480.0                |
|bert            |eval |1         |0.10294417496565934          |763363328.0           |684779520.0                  |504081664               |2.351062297821045        |504081664.0                 |
|bert            |eval |64        |0.030267890650357027         |12922650624.0         |12531509248.0                |999549952               |3.966449499130249        |999549952.0                 |
|bert            |train|1         |0.16336805555555556          |1793064960.0          |1500135424.0                 |993222656               |6.086249113082886        |757365760.0                 |
|efficientnet    |eval |1         |0.09972972601232394          |148897792.0           |134048256.0                  |30956440                |0.5194971561431885       |30956048.0                  |
|efficientnet    |eval |64        |0.02773516099353996          |7426015232.0          |7220053504.0                 |637885336               |0.5310900211334229       |637884944.0                 |
|efficientnet    |eval |32        |0.055235360035927335         |3867148288.0          |3653544960.0                 |329603992               |0.524756669998169        |329603600.0                 |
|efficientnet    |train|1         |0.08707356770833333          |157286400.0           |143590912.0                  |120098880               |465.6447603702545        |90201796.0                  |
|efficientnet    |train|64        |0.35869177021459353          |9003073536.0          |5773745152.0                 |5704096952              |715.3019030094147        |4123529104.0                |
|efficientnet    |train|32        |0.355987338362069            |4561305600.0          |2937538560.0                 |2865355832              |1537.194652557373        |2072345872.0                |
|efficientnet    |train|128       |0.09984404223014633          |12754878464.0         |11481379840.0                |11381579192             |1083.9673562049866       |8225567888.0                |
|googlenet       |eval |1         |0.16846454326923077          |136314880.0           |113350656.0                  |58502840                |0.4997739791870117       |32980384.0                  |
|googlenet       |eval |64        |0.037223945897328345         |4062183424.0          |3910972928.0                 |463122104               |0.4992830753326416       |437599648.0                 |
|googlenet       |eval |32        |0.04407169407479818          |2078277632.0          |1986684416.0                 |257601208               |0.5088262557983398       |232078752.0                 |
|googlenet       |eval |128       |0.04065242228031777          |8084520960.0          |7755865600.0                 |874163896               |0.5275917053222656       |848641440.0                 |
|googlenet       |train|128       |0.27401727552158167          |8757706752.0          |6357943808.0                 |6281451992              |3.642225742340088        |6287620192.0                |
|inception       |eval |1         |0.0872664741847826           |241172480.0           |220126208.0                  |119854528               |1.2693455219268799       |106539808.0                 |
|inception       |eval |64        |0.0726284071831538           |7690256384.0          |7131725312.0                 |816874432               |1.293694257736206        |803559712.0                 |
|inception       |eval |32        |0.16050705400485438          |4320133120.0          |3626721280.0                 |462832576               |1.3401761054992676       |449517856.0                 |
|inception       |train|1         |0.11245798510174419          |541065216.0           |480218112.0                  |366726488               |13.18757963180542        |313715096.0                 |
|inception       |train|64        |0.18365958709400879          |8103395328.0          |6615129088.0                 |6472836192              |11.970948219299316       |6455378368.0                |
|inception       |train|32        |0.18987097874659822          |4238344192.0          |3433605632.0                 |3298162400              |12.242316722869873       |3282001984.0                |
|inception       |train|128       |0.13232454201991686          |14254342144.0         |12368142848.0                |12826967904             |11.50382685661316        |12791394496.0               |
|mnasnet         |eval |1         |0.2728678385416667           |50331648.0            |36597760.0                   |11365408                |0.4805293083190918       |11364992.0                  |
|mnasnet         |eval |64        |0.10074938322368421          |1992294400.0          |1791571968.0                 |163097632               |0.4923820495605469       |163097216.0                 |
|mnasnet         |eval |256       |0.06129418349847561          |7566524416.0          |7102740480.0                 |625519648               |0.4850478172302246       |625519232.0                 |
|mnasnet         |eval |32        |0.12245711966306584          |1019215872.0          |894405632.0                  |86027296                |0.4978303909301758       |86026880.0                  |
|mnasnet         |eval |128       |0.07147828150656814          |3831496704.0          |3557627904.0                 |317238304               |0.4889953136444092       |317237888.0                 |
|mnasnet         |eval |512       |0.048635425376254184         |14422114304.0         |13720688640.0                |1242082336              |0.512383222579956        |1242081920.0                |
|mnasnet         |train|1         |0.09734637920673077          |54525952.0            |49218048.0                   |40175488                |2.4274988174438477       |39298912.0                  |
|mnasnet         |train|64        |0.18554984930203045          |2065694720.0          |1682405376.0                 |1654316544              |2.6736814975738525       |1649192128.0                |
|mnasnet         |train|256       |0.15407965780580835          |7834959872.0          |6627751936.0                 |6574775808              |2.6123569011688232       |6569651392.0                |
|mnasnet         |train|32        |0.16098663266632016          |1008730112.0          |846338048.0                  |834240000               |2.510664224624634        |829115584.0                 |
|mnasnet         |train|128       |0.16097598471341787          |3969908736.0          |3330848768.0                 |3294469632              |2.6493077278137207       |3289345216.0                |
|mnasnet         |train|512       |0.08080364903564632          |14325645312.0         |13168080896.0                |13135388160             |2.6024270057678223       |13130263744.0               |
|mobilenet       |eval |1         |0.626742493872549            |106954752.0           |39921664.0                   |23790144                |0.42606306076049805      |23789728.0                  |
|mobilenet       |eval |64        |0.6834353698211756           |5182062592.0          |1640457728.0                 |630719040               |0.4059605598449707       |630718624.0                 |
|mobilenet       |eval |32        |0.6834378200564548           |2623537152.0          |830512640.0                  |322437696               |0.41846561431884766      |322437280.0                 |
|mobilenet       |eval |128       |0.6805896715924851           |10206838784.0         |3260169728.0                 |1247281728              |0.4168522357940674       |1247281312.0                |
|mobilenet       |train|1         |0.13448715209960938          |134217728.0           |116167168.0                  |100250336               |5.523818016052246        |73449792.0                  |
|mobilenet       |train|64        |0.10756033209589923          |5702156288.0          |5088830464.0                 |5056284384              |4.640833616256714        |3504133536.0                |
|mobilenet       |train|32        |0.09887123387170571          |2864709632.0          |2581472256.0                 |2537850592              |4.582365036010742        |1759212960.0                |
|mobilenet       |train|128       |0.0977976209573922           |11234443264.0         |10135741440.0                |10093151968             |4.802807569503784        |6993974688.0                |
|resnet          |eval |1         |0.3336136429398148           |113246208.0           |75465728.0                   |53219136                |0.20397114753723145      |53218976.0                  |
|resnet          |eval |64        |0.06674510908324689          |2021654528.0          |1886718976.0                 |457838400               |0.19954919815063477      |457838240.0                 |
|resnet          |eval |256       |0.061656818466288385         |7853834240.0          |7369591808.0                 |1690963776              |0.20170068740844727      |1690963616.0                |
|resnet          |eval |32        |0.10997778131056202          |1082130432.0          |963120128.0                  |252317504               |0.19915008544921875      |252317344.0                 |
|resnet          |eval |128       |0.08334877405715396          |4045406208.0          |3708226560.0                 |868880192               |0.19780182838439941      |868880032.0                 |
|resnet          |train|1         |0.12812943892045456          |184549376.0           |160903168.0                  |110699744               |0.8460609912872314       |77743264.0                  |
|resnet          |train|64        |0.3092943075117371           |2233466880.0          |1542668288.0                 |1432745184              |0.8922193050384521       |1430688928.0                |
|resnet          |train|256       |0.3334782869481766           |8740929536.0          |5826019328.0                 |5572261088              |0.8790616989135742       |5570208928.0                |
|resnet          |train|32        |0.2729100136861314           |1149239296.0          |835600384.0                  |756806880               |0.8715600967407227       |743478432.0                 |
|resnet          |train|128       |0.3085975721624266           |4286578688.0          |2963750912.0                 |2810574048              |0.9011383056640625       |2808521888.0                |
|resnet          |train|512       |0.16961779389600604          |13914603520.0         |11554439168.0                |11095635168             |0.874251127243042        |11093583008.0               |
|resnet50        |eval |1         |0.14260646275111608          |234881024.0           |201385472.0                  |112074824               |0.6637256145477295       |112074400.0                 |
|resnet50        |eval |64        |0.03515352260712576          |6570377216.0          |6339405312.0                 |719003720               |0.6681668758392334       |719003296.0                 |
|resnet50        |eval |32        |0.058045181573606004         |3422552064.0          |3223889408.0                 |410722376               |0.67303466796875         |410721952.0                 |
|resnet50        |eval |128       |0.029234314460098183         |12922650624.0         |12544865792.0                |1335566408              |0.6985859870910645       |1335565984.0                |
|resnet50        |train|1         |0.07081722595531088          |404750336.0           |376087040.0                  |268574184               |3.3523597717285156       |197569696.0                 |
|resnet50        |train|64        |0.16812118148458696          |6956253184.0          |5786759680.0                 |5659913704              |2.7866032123565674       |5651717280.0                |
|resnet50        |train|32        |0.16024192090473052          |3579838464.0          |3006198272.0                 |2885381608              |2.8536908626556396       |2877185184.0                |
|resnet50        |train|128       |0.15144446418227694          |13350469632.0         |11328614912.0                |11208977896             |2.8609697818756104       |11200781472.0               |
|resnet3d        |eval |1         |0.293365478515625            |218103808.0           |154119680.0                  |135932896               |0.20641589164733887      |135932736.0                 |
|resnet3d        |eval |64        |0.09786107349980828          |1367343104.0          |1233533440.0                 |287665120               |0.2042398452758789       |287664960.0                 |
|resnet3d        |eval |256       |0.06929405741897643          |4804575232.0          |4471646720.0                 |750087136               |0.2064664363861084       |750086976.0                 |
|resnet3d        |eval |32        |0.10808838563188705          |761266176.0           |678982144.0                  |210594784               |0.2042524814605713       |210594624.0                 |
|resnet3d        |eval |128       |0.09117493129386871          |2539651072.0          |2308098560.0                 |441805792               |0.20145082473754883      |441805632.0                 |
|resnet3d        |eval |512       |0.0632103511265346           |9395240960.0          |8801364480.0                 |1366649824              |0.21191716194152832      |1366649664.0                |
|resnet3d        |train|1         |0.049133590047393365         |442499072.0           |420757504.0                  |275715104               |0.8879842758178711       |176471360.0                 |
|resnet3d        |train|64        |0.1933536305147059           |1604321280.0          |1294119936.0                 |1142786080              |0.8512494564056396       |1096347968.0                |
|resnet3d        |train|256       |0.20534075199331275          |5096079360.0          |4049646592.0                 |3900606496              |0.9507899284362793       |3899781440.0                |
|resnet3d        |train|32        |0.1615112045514862           |987758592.0           |828224512.0                  |688392224               |0.831167459487915        |629109056.0                 |
|resnet3d        |train|128       |0.20525947605427383          |2772434944.0          |2203366400.0                 |2051573792              |0.8712570667266846       |2030825792.0                |
|resnet3d        |train|512       |0.22026404008038333          |10011803648.0         |7806563328.0                 |7661586464              |0.8873775005340576       |7660765504.0                |
|squeezenet      |eval |1         |0.2181396484375              |62914560.0            |49190400.0                   |10965664                |0.08942198753356934      |10965664.0                  |
|squeezenet      |eval |64        |0.11205277582062334          |3162505216.0          |2808137728.0                 |387199648               |0.09076166152954102      |387199648.0                 |
|squeezenet      |eval |256       |0.10406191580196605          |12480151552.0         |11181443072.0                |1533817504              |0.08925986289978027      |1533817504.0                |
|squeezenet      |eval |32        |0.11529935050230566          |1591738368.0          |1408211968.0                 |196096672               |0.09017658233642578      |196096672.0                 |
|squeezenet      |eval |128       |0.0846176670739026           |6115295232.0          |5597833216.0                 |769405600               |0.08980679512023926      |769405600.0                 |
|squeezenet      |train|1         |0.24788936491935484          |65011712.0            |48896000.0                   |43337152                |0.2514674663543701       |42899552.0                  |
|squeezenet      |train|64        |0.29469899039956465          |3372220416.0          |2378430464.0                 |2364017312              |0.25309157371520996      |2364017312.0                |
|squeezenet      |train|256       |0.3254965690951953           |14011072512.0         |9450516480.0                 |9441088160              |0.2517416477203369       |9441088160.0                |
|squeezenet      |train|32        |0.29656493237515413          |1700790272.0          |1196395520.0                 |1184505504              |0.24597406387329102      |1184505504.0                |
|squeezenet      |train|128       |0.326526617954071            |7031750656.0          |4735696896.0                 |4723040928              |0.25419068336486816      |4723040928.0                |
|transformer     |eval |1         |0.3623153023097826           |48234496.0            |30758400.0                   |29802496                |0.11122417449951172      |29802496.0                  |
|transformer     |train|1         |0.05078125                   |96468992.0            |91570176.0                   |58943488                |0.3672466278076172       |36416212.0                  |
|transformer     |train|64        |0.12943745707417584          |190840832.0           |166138880.0                  |131724032               |0.3046841621398926       |125575940.0                 |
|transformer     |train|256       |0.24772638799398625          |610271232.0           |459090944.0                  |425987072               |0.3064579963684082       |414002180.0                 |
|transformer     |train|1024      |0.12240831102029312          |1860173824.0          |1632473088.0                 |1603039232              |0.3077516555786133       |1567707140.0                |
|transformer     |train|4096      |0.13726357494295494          |7352614912.0          |6343368704.0                 |6311247872              |0.3116629123687744       |6182526980.0                |
|transformer     |train|32        |0.07269183659957627          |123731968.0           |114737664.0                  |82680192                |0.302309513092041        |77504900.0                  |
|transformer     |train|128       |0.23098829315929878          |343932928.0           |264488448.0                  |229811712               |0.29776644706726074      |221718020.0                 |
|transformer     |train|512       |0.10453755876659292          |947912704.0           |848820224.0                  |818337792               |0.3082082271575928       |798570500.0                 |
|transformer     |train|2048      |0.1258094232970807           |3663724544.0          |3202793472.0                 |3172442112              |0.30730271339416504      |3105980420.0                |
|transformer_dflt|eval |1         |0.051978326612903226         |195035136.0           |184897536.0                  |176951296               |3.2719085216522217       |176951296.0                 |
|transformer_dflt|eval |64        |0.016489955357142858         |587202560.0           |577519616.0                  |201465856               |3.667842149734497        |201465856.0                 |
|transformer_dflt|eval |256       |0.02879067517201835          |1828716544.0          |1776066560.0                 |276176896               |3.8760688304901123       |276176896.0                 |
|transformer_dflt|eval |1024      |0.03691309918310728          |6803161088.0          |6552035328.0                 |575021056               |3.9322993755340576       |575021056.0                 |
|transformer_dflt|eval |128       |0.0268544493736952           |1004535808.0          |977559552.0                  |226369536               |4.05011773109436         |226369536.0                 |
|transformer_dflt|eval |512       |0.033315940884476536         |3485466624.0          |3369345024.0                 |375791616               |4.151917457580566        |375791616.0                 |
|transformer_dflt|eval |2048      |0.036680774265395434         |13417578496.0         |12925411328.0                |973479936               |3.6822707653045654       |973479936.0                 |
|transformer_dflt|train|1         |0.0952737145390071           |591396864.0           |535052288.0                  |353200128               |47.65722870826721        |190272112.0                 |
|transformer_dflt|train|64        |0.03513986472315436          |937426944.0           |904485888.0                  |710884352               |11.872873544692993       |704736260.0                 |
|transformer_dflt|train|256       |0.05889126627861089          |2657091584.0          |2500612096.0                 |2301243392              |16.185761213302612       |2289258500.0                |
|transformer_dflt|train|32        |0.008773311491935484         |650117120.0           |644413440.0                  |445824512               |11.396814584732056       |440649220.0                 |
|vgg             |eval |1         |0.07966316393769968          |656408576.0           |604116992.0                  |547509664               |0.05366086959838867      |547509664.0                 |
|vgg             |eval |64        |0.09090510385479042          |5603590144.0          |5094195200.0                 |1559057824              |0.05647730827331543      |1559057824.0                |
|vgg             |eval |32        |0.23972562190155808          |3701473280.0          |2814135296.0                 |1045255584              |0.04882240295410156      |1045255584.0                |
|vgg             |eval |128       |0.19915675951086956          |12058624000.0         |9657067520.0                 |2586662304              |0.05761313438415527      |2586662304.0                |
|vgg             |train|1         |0.05257339015151515          |1730150400.0          |1639190528.0                 |1106228544              |0.14355158805847168      |991298976.0                 |
|vgg             |train|64        |0.37579814945577295          |7610564608.0          |4750528512.0                 |4217632064              |0.14405608177185059      |4064908704.0                |
|vgg             |train|32        |0.34506140814887154          |4831838208.0          |3164557312.0                 |2631267648              |0.14167547225952148      |2503710112.0                |
|vgg             |train|128       |0.44043706269435806          |14162067456.0         |7924568064.0                 |7390360896              |0.14803528785705566      |7187305888.0                |
|vgg16           |eval |1         |0.08101447610294117          |713031680.0           |655265792.0                  |579120288               |0.05828094482421875      |579120288.0                 |
|vgg16           |eval |64        |0.12718688770257705          |7893680128.0          |6889707520.0                 |2197597344              |0.06188201904296875      |2197597344.0                |
|vgg16           |eval |32        |0.17308103421925944          |4502585344.0          |3723273216.0                 |1375513760              |0.05724191665649414      |1375513760.0                |
|vgg16           |eval |128       |0.046527725279709706         |13870563328.0         |13225197568.0                |3841764512              |0.06003069877624512      |3841764512.0                |
|vgg16           |train|1         |0.06860462033371041          |1853882368.0          |1726697472.0                 |1169562688              |0.18282079696655273      |1037761696.0                |
|vgg16           |train|64        |0.3350135216346154           |9542041600.0          |6345328640.0                 |5790454848              |0.18207740783691406      |5653982368.0                |
|vgg16           |train|32        |0.35845803217717465          |6220152832.0          |3990489088.0                 |3433387072              |0.18488550186157227      |3309235360.0                |
|vgg16           |train|128       |0.20315554063113764          |13881049088.0         |11061037056.0                |10504590400             |0.18082427978515625      |10343476384.0               |
|vgg19           |eval |1         |0.07471816016737892          |736100352.0           |681100288.0                  |600359072               |0.0649561882019043       |600359072.0                 |
|vgg19           |eval |64        |0.08715420293505549          |7935623168.0          |7244000256.0                 |2218836128              |0.06863236427307129      |2218836128.0                |
|vgg19           |eval |32        |0.18784409366833624          |4815060992.0          |3910580224.0                 |1396752544              |0.06816816329956055      |1396752544.0                |
|vgg19           |train|1         |0.06872345370496726          |1920991232.0          |1788974080.0                 |1212891200              |0.2088029384613037       |1064218784.0                |
|vgg19           |train|64        |0.3210858280022298           |9875488768.0          |6704609280.0                 |6129414208              |0.19965076446533203      |6009192608.0                |
|vgg19           |train|32        |0.25086289822698354          |5603590144.0          |4197857280.0                 |3618205760              |0.19731593132019043      |3497459872.0                |
|vgg19           |train|128       |0.184550687390782            |14401142784.0         |11743401984.0                |11165454400             |0.20167112350463867      |11032658080.0               |
|vit             |eval |1         |0.09024203431372549          |534773760.0           |486514688.0                  |351717280               |0.5084536075592041       |351717280.0                 |
|vit             |eval |64        |0.05329670888479063          |9665773568.0          |9150619648.0                 |694856608               |1.290839433670044        |694856608.0                 |
|vit             |eval |32        |0.060462967456004144         |5064622080.0          |4758400000.0                 |520563616               |1.2642536163330078       |520563616.0                 |
|vit             |train|1         |0.16455570509453782          |1247805440.0          |1042471936.0                 |694395240               |3.005735158920288        |495502240.0                 |
|vit             |train|64        |0.033396262438131576         |10169090048.0         |9829480448.0                 |9460563776              |2.8146584033966064       |9448041376.0                |
|vit             |train|32        |0.03662389781537136          |5477761024.0          |5277144064.0                 |4909678400              |2.793891429901123        |4897156000.0                |
|xlmr            |eval |1         |0.058556590087519025         |1377828864.0          |1297147904.0                 |1117673728              |2.3110616207122803       |1117673728.0                |
|xlmr            |eval |64        |0.029048914359024014         |13537116160.0         |13143877632.0                |1613142016              |4.059075355529785        |1613142016.0                |
|xlmr            |train|1         |0.08216021932670127          |3636461568.0          |3337689088.0                 |2220406784              |3.271420955657959        |1878603776.0                |
